### PR TITLE
Remove redundant home-directory wrappers

### DIFF
--- a/src/sources/CaptureLocations.cpp
+++ b/src/sources/CaptureLocations.cpp
@@ -8,17 +8,15 @@
 
 namespace {
 
-QString home() { return QDir::homePath(); }
-
 QString normalizedUserDir(QString value) {
   if (value.startsWith(QStringLiteral("$HOME"))) {
-    value.replace(0, 5, home());
+    value.replace(0, 5, QDir::homePath());
   } else if (QDir::isRelativePath(value)) {
-    value = home() + QLatin1Char('/') + value;
+    value = QDir::homePath() + QLatin1Char('/') + value;
   }
   // xdg-user-dirs uses $HOME to mean "disabled". Scanning it recursively
   // would pull media from repositories, caches and unrelated applications.
-  return QDir::cleanPath(value) == QDir::cleanPath(home()) ? QString() : value;
+  return QDir::cleanPath(value) == QDir::cleanPath(QDir::homePath()) ? QString() : value;
 }
 
 // XDG user dirs live in a shell-fragment file rather than anywhere Qt reads, and
@@ -32,7 +30,7 @@ QString xdgUserDir(const QString& key) {
   }
 
   const QString configHome = qEnvironmentVariable("XDG_CONFIG_HOME").isEmpty()
-                                 ? home() + QStringLiteral("/.config")
+                                 ? QDir::homePath() + QStringLiteral("/.config")
                                  : qEnvironmentVariable("XDG_CONFIG_HOME");
 
   QFile file(configHome + QStringLiteral("/user-dirs.dirs"));
@@ -65,7 +63,7 @@ QString resolve(const QString& override, const QString& xdgKey, const QString& f
   if (!xdg.isEmpty()) {
     return xdg;
   }
-  return home() + QLatin1Char('/') + fallbackLeaf;
+  return QDir::homePath() + QLatin1Char('/') + fallbackLeaf;
 }
 
 } // namespace

--- a/src/theme/OmarchyTheme.cpp
+++ b/src/theme/OmarchyTheme.cpp
@@ -16,14 +16,6 @@
 #include <cmath>
 
 namespace {
-QString defaultStateHome() {
-  return QDir::homePath() + QStringLiteral("/.local/state");
-}
-
-QString defaultConfigHome() {
-  return QDir::homePath() + QStringLiteral("/.config");
-}
-
 QJsonObject hyprlandOption(const QString &option) {
   const QString executable =
       QStandardPaths::findExecutable(QStringLiteral("hyprctl"));
@@ -52,7 +44,8 @@ double linearChannel(double channel) {
 } // namespace
 
 OmarchyTheme::OmarchyTheme(QObject *parent)
-    : OmarchyTheme(defaultStateHome(), defaultConfigHome(), parent) {}
+    : OmarchyTheme(QDir::homePath() + QStringLiteral("/.local/state"),
+                   QDir::homePath() + QStringLiteral("/.config"), parent) {}
 
 OmarchyTheme::OmarchyTheme(QString stateHome, QString configHome,
                            QObject *parent)


### PR DESCRIPTION
Call Qt's home-directory lookup directly and inline the two default paths used by the theme constructor.

Validation: Debug build and all three CTest targets, including the UI suite.
