### PR TITLE
Defer video setup until a video is opened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         run: >-
           pacman -Syu --noconfirm --needed
           appstream base-devel cmake desktop-file-utils ffmpeg ffmpegthumbnailer
-          git imagemagick kimageformats libavif libheif ninja pkgconf poppler qt6-base
+          git imagemagick kimageformats libavif libheif ninja pkgconf poppler python qt6-base
           qt6-declarative qt6-imageformats qt6-multimedia qt6-svg qt6-wayland
           wl-clipboard xdg-desktop-portal xdg-utils mesa xorg-server-xvfb xorg-xauth
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -28,12 +28,16 @@ jobs:
         run: ctest --test-dir build/release --output-on-failure
       - name: Test rendered media with Mesa OpenGL
         run: xvfb-run -a bash tests/run-opengl.sh build/release
+      - name: Check startup readiness (informational timings)
+        run: xvfb-run -a python3 tests/benchmark_startup.py build/release/omaroll --runs 1 > build/release/startup.json
       - name: Save rendered views
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opengl-renders
-          path: build/release/opengl-renders/*.png
+          path: |
+            build/release/opengl-renders/*.png
+            build/release/startup.json
           if-no-files-found: ignore
           retention-days: 7
       - name: Validate metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Defer video setup until a video is opened, reducing startup work for images and the library.
+
 - Keep automated playback and headless renders off physical audio devices, including native PipeWire.
 
 - Open multiple selected files in order, including across folders and in an already-running window.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ qt_add_resources(omaroll_core "omaroll_demo_media"
     resources/demo/winter-cabin.jpg
 )
 
-qt_add_executable(omaroll src/app/main.cpp)
+qt_add_executable(omaroll src/app/main.cpp src/app/StartupTrace.h)
 
 qt_add_resources(omaroll "omaroll_icons"
   PREFIX "/icons"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,16 @@
 Bug reports and focused pull requests are welcome. Before opening a pull request:
 
 ```bash
-cmake -S . -B build -G Ninja
-cmake --build build
-ctest --test-dir build --output-on-failure
+cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build/release
+bash tests/run-isolated.sh build/release
 ```
 
 Keep changes small, preserve the local-first design, and include a regression
 test when fixing behavior that can be exercised without a desktop session.
+
+Local tests require `bubblewrap`. Use the isolated runner for media tests and
+renders, including sanitizer builds. See [validation](tests/README.md) for
+OpenGL checks and [project status](docs/STATUS.md) before choosing new work.
+Keep PRs in draft until their code and public description are ready; leave
+session work open for review rather than merging it automatically.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ You can also choose Omaroll from a file manager's **Open With** menu and set it
 as the default for the media types you want. A single file opens directly in the
 viewer, with previous and next navigation through other media in that folder.
 
+Current main also supports ordered file selections (unreleased since 1.4.0):
+
+```bash
+omaroll first.jpg ~/Pictures/second.png third.webp
+omaroll -- ./-unusual-name.png
+```
+
+Multiple files stay in the supplied order across folders, including when an
+existing window receives them. Explicitly selected hidden files can be opened
+without scanning every surrounding folder. The viewer shows your position in
+the selection and skips removed files.
+
 ### Transparency
 
 Omaroll paints its own translucent chrome from your theme and draws every
@@ -295,11 +307,12 @@ graph rather than the screen, so an overlapping window cannot spoil the shot.
 ## Development
 
 ```bash
-cmake -S . -B build -G Ninja
-cmake --build build
-ctest --test-dir build --output-on-failure
+cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build/release
+bash tests/run-isolated.sh build/release
 ```
 
+See [current project status](docs/STATUS.md) for released, merged and draft work.
 See [validation](tests/README.md) for the OpenGL media checks and
 [the roadmap](docs/ROADMAP.md) for upcoming work.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,22 @@
 # Releasing Omaroll
 
+Start with [current status](docs/STATUS.md). v1.4.0 is the latest release in the
+5 September 2026 handoff. Merged work and draft PR #6 do not constitute a new
+release; no next version has been selected.
+
 1. Update the version in `CMakeLists.txt`, AppStream metadata, the changelog,
    README package command, and public feature descriptions.
-2. Run a clean Release build, the tests, metadata validation, and a staged install.
-3. Run the sanitizer build and render every deterministic view.
+2. Run a clean Release build, tests through `tests/run-isolated.sh`, metadata
+   validation, and a staged install. See [validation](tests/README.md).
+3. Run the sanitizer build and render every deterministic view inside the local
+   audio sandbox. Check rendered video with OpenGL.
 4. Test the exact candidate on a real Omarchy desktop using the checklist in README.
 5. Tag the approved commit as `vX.Y.Z` and push the tag.
 6. Confirm the Release workflow tests the package lifecycle and publishes the
    source archive, Arch package, checksums, and signed provenance.
 7. Download the public artifacts and verify their checksums before announcing.
+
+Record the exact candidate commit and any untested hardware or desktop behavior.
+Upstream package acceptance and MIME defaults remain separate from releasing.
 
 Do not publish while a source checksum or package URL is a placeholder.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,12 +4,17 @@ Omaroll should cover everyday media viewing and organization on Omarchy:
 open files quickly, find them again, make a quick correction, and share the
 result. Discovery stays read-only and core use stays offline.
 
+See [current status and handoff](STATUS.md) for release boundaries and evidence.
+
 ## Reliability and package adoption
 
-- Run real animated-image, video, audio and subtitle checks in ordinary CI.
+- Maintain the animated-image, video-track, subtitle and rendered-pixel checks
+  already running in CI. Local tests stay audio-isolated.
 - Verify installed behavior on Omarchy: file-manager opening, scaling,
   clipboard, drag/drop, window state and physical audio.
-- Measure current startup time, library responsiveness and resource use.
+- Review draft PR #6 for deferred video setup and content-ready startup timing.
+- Extend recorded startup and 10k/50k library baselines with warm navigation,
+  larger/mixed libraries, compositor presentation and regression budgets.
 - Maintain the [Omarchy package submission](https://github.com/omacom/omarchy-pkgs/pull/295).
 
 ## Complete image workflows

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -36,7 +36,7 @@ a human review. The documentation handoff follows in the same PR. Check CI on
 its latest head before merging.
 
 [Local measurements](performance/2026-09-05-startup/README.md) record medians
-of 949.9 to 259.9 ms for an image-ready submitted frame and 1181.2 to 440.9 ms
+of 949.9 to 257.2 ms for an image-ready submitted frame and 1181.2 to 471.9 ms
 for a ready grid. These are offscreen NVIDIA measurements from main entry,
 not compositor presentation or general performance guarantees.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,81 @@
+# Project status and handoff
+
+Snapshot: 5 September 2026 UTC. Check the linked PRs and release before resuming.
+
+## Released
+
+[v1.4.0](https://github.com/btsouth/omaroll/releases/tag/v1.4.0) remains the latest
+public release. No newer tag or package was published during this session.
+The viewer supports still and animated images, embedded video controls, PDF
+paging, OCR/QR, albums, tags, saved collections and duplicate review. The
+README describes the supported formats and workflows.
+
+## Merged, awaiting a release
+
+Main is at `3f8703b` in this snapshot:
+
+- [PR #3](https://github.com/btsouth/omaroll/pull/3): home-directory wrapper cleanup.
+- [PR #4](https://github.com/btsouth/omaroll/pull/4): natural filename sorting,
+  accessible OCR copy feedback and rendered media checks in CI/release validation.
+- [PR #5](https://github.com/btsouth/omaroll/pull/5): ordered multi-file opening,
+  selection forwarding to an existing window, performance baselines and isolated
+  media tests. Selected files remain discoverable after supported file actions.
+
+## Open for review
+
+[Draft PR #6](https://github.com/btsouth/omaroll/pull/6), branch
+`codex/startup-readiness`, defers both the video player and display until a video
+is opened. It also measures a decoded image or fully loaded viewport followed
+by frame submission. The first video still pays the initialization cost.
+
+Application changes are committed at `79f59fc`. At that commit, 88 core checks,
+52 UI checks, ASan/UBSan, OpenGL rendering and GitHub CI/CodeQL passed. The
+startup probe also passed under sanitizers and in CI on Mesa llvmpipe.
+CodeRabbit skipped review because the PR is a draft; automated checks are not
+a human review. The documentation handoff follows in the same PR. Check CI on
+its latest head before merging.
+
+[Local measurements](performance/2026-09-05-startup/README.md) record medians
+of 949.9 to 259.9 ms for an image-ready submitted frame and 1181.2 to 440.9 ms
+for a ready grid. These are offscreen NVIDIA measurements from main entry,
+not compositor presentation or general performance guarantees.
+
+## Next decisions and release gates
+
+1. Review PR #6 and address feedback. Leave it open until review and merge are
+   explicitly requested. Keep subsequent changes in separate focused PRs.
+2. Finish installed Omarchy acceptance (SBS-1121): file-manager selections,
+   clipboard, drag/drop, scaling, window state and physical audio. Headless
+   passes do not close this gate.
+3. Continue performance work (SBS-1122): warm navigation, larger and mixed
+   libraries, Wayland presentation, GPU memory and realistic regression budgets.
+4. Start safe image corrections (SBS-1126): crop, rotate and resize with Save a
+   copy, collision handling and a metadata/color policy. Reuse Omarchy helpers
+   where they satisfy the workflow. Comparison and organization improvements
+   follow in the [roadmap](ROADMAP.md).
+5. Choose and validate the next release only after review and acceptance.
+   Follow [RELEASING.md](../RELEASING.md); no new version is selected yet.
+
+[Official package PR #295](https://github.com/omacom/omarchy-pkgs/pull/295)
+remains open and targets v1.4.0. Earlier edge, rc and stable package builds
+passed; upstream acceptance is pending. Repository inclusion, default
+installation and MIME defaults are separate upstream decisions.
+
+## Safe continuation
+
+Use [the validation commands](../tests/README.md), always through
+`tests/run-isolated.sh` on this desktop. Earlier tests played 440/880 Hz fixture
+tones because blocking PulseAudio alone did not block Qt's native PipeWire
+backend. PR #5 isolates both backends, hides physical audio devices and session
+sockets, and stubs test notifications and clipboard helpers. Preserve this
+isolation; do not change host audio settings to make a test pass.
+
+The checked-in fixtures cover GIF, animated/still WebP, transparency, TGA,
+video tracks and subtitles. No media downloads are needed for those checks.
+Physical audio testing remains a deliberate desktop acceptance activity.
+
+Linear is the active task tracker. Access it through Toolport. SBS-1093 is the
+parent roadmap; SBS-1125 is done, while SBS-1121 and SBS-1122 remain in progress.
+Notes under `build/roadmap-review/` are historical and ignored by Git. This
+file is the committed handoff. No further implementation, merge or release
+work is scheduled by closing this session.

--- a/docs/performance/2026-09-05-startup/README.md
+++ b/docs/performance/2026-09-05-startup/README.md
@@ -1,0 +1,73 @@
+# Deferred video setup, 5 September 2026
+
+Opening a still image or the library constructed both a `MediaPlayer` and a
+`VideoOutput`, even while the viewer was hidden. A diagnostic construction
+probe attributed roughly 740 ms to multimedia backend initialization on this
+machine. Deferring only the player did not help: the video output's sink also
+initializes that backend. Both are now created on the first video request and
+retained for later playback. The first video still pays this setup cost.
+
+## Local comparison
+
+Intel Core i7-14700F, 28 logical CPUs, Linux 7.2.3-arch1-2, Qt 6.11.2, Release.
+Offscreen NVIDIA RTX 4070 SUPER OpenGL, driver 610.57.04. The software-rendering
+request did not select Mesa. Btrfs fixtures, warm filesystem caches, fresh
+settings and application cache for every launch. No concurrent builds or tests.
+All processes ran inside `tests/run-isolated.sh` with audio devices and session
+sockets hidden.
+
+Each mode launched three times before and three times after the change. The
+baseline uses the same readiness instrumentation with the original eager
+player and output. Each library contains 100 copies of the 160x100 transparent
+PNG fixture. Hashes and individual samples are in [before.json](before.json)
+and [after.json](after.json).
+
+| Median time from main entry | Eager video setup | Deferred video setup |
+| --- | ---: | ---: |
+| QML loaded, single-image launch | 810.3 ms | 78.7 ms |
+| Requested image frame submitted | 949.9 ms | 259.9 ms |
+| QML loaded, library launch | 837.6 ms | 77.1 ms |
+| Ready viewport frame submitted | 1181.2 ms | 440.9 ms |
+
+Process RSS after eight seconds ranged from 328.1 to 328.7 MiB before and
+250.0 to 251.0 MiB after. This excludes GPU memory. No CPU ticks were observed
+in the five-second idle samples; that is not a claim of zero ongoing work.
+
+A separate [photographic fixture check](photo.json) used 100 copies of the
+1536x1024 `alpine-dawn.jpg` demo image. One launch per mode reached an image
+frame at 258.3 ms and a ready grid at 443.6 ms. This checks that the probe works
+with JPEG photography; one sample is not a comparative benchmark.
+
+## Reproduce
+
+Build a Release executable and run from the repository root:
+
+```sh
+mkdir -p build/release/benchmark-fixtures
+TMPDIR="$PWD/build/release/benchmark-fixtures" \
+  bash tests/run-isolated.sh build/release \
+  python3 tests/benchmark_startup.py build/release/omaroll
+```
+
+The before comparison was built with the original `DetailSheet.qml` from
+`3f8703b`, plus the new `imageReady` property, while retaining this PR's tracing
+and other readiness checks. The after comparison uses the deferred player and
+output. See [metric definitions](../../../tests/README.md#performance).
+
+## Limits and remaining work
+
+These metrics observe decoded QML content followed by a submitted scene-graph
+frame. They do not read pixels back or establish when a compositor presents
+that frame. Process spawning and dynamic loading before main are excluded.
+This replaces the older diagnostic first-frame metric, so the old startup
+numbers are not directly comparable.
+
+The first-image predicate rejects errors and checks the requested path. The
+grid predicate requires all intersecting cells, including a partial bottom row,
+to have decoded thumbnails at full opacity after scanning settles. Empty or
+failed libraries do not count as ready.
+
+The small repeated fixture isolates initialization. Warm navigation, large
+photographs, mixed media libraries, physical video/audio playback, Wayland
+presentation, GPU memory and useful regression budgets still need separate
+measurements. These results are not a release performance guarantee.

--- a/docs/performance/2026-09-05-startup/README.md
+++ b/docs/performance/2026-09-05-startup/README.md
@@ -24,18 +24,18 @@ and [after.json](after.json).
 
 | Median time from main entry | Eager video setup | Deferred video setup |
 | --- | ---: | ---: |
-| QML loaded, single-image launch | 810.3 ms | 78.7 ms |
-| Requested image frame submitted | 949.9 ms | 259.9 ms |
-| QML loaded, library launch | 837.6 ms | 77.1 ms |
-| Ready viewport frame submitted | 1181.2 ms | 440.9 ms |
+| QML loaded, single-image launch | 810.3 ms | 76.7 ms |
+| Requested image frame submitted | 949.9 ms | 257.2 ms |
+| QML loaded, library launch | 837.6 ms | 77.9 ms |
+| Ready viewport frame submitted | 1181.2 ms | 471.9 ms |
 
 Process RSS after eight seconds ranged from 328.1 to 328.7 MiB before and
-250.0 to 251.0 MiB after. This excludes GPU memory. No CPU ticks were observed
+252.7 to 254.8 MiB after. This excludes GPU memory. No CPU ticks were observed
 in the five-second idle samples; that is not a claim of zero ongoing work.
 
 A separate [photographic fixture check](photo.json) used 100 copies of the
 1536x1024 `alpine-dawn.jpg` demo image. One launch per mode reached an image
-frame at 258.3 ms and a ready grid at 443.6 ms. This checks that the probe works
+frame at 287.4 ms and a ready grid at 470.2 ms. This checks that the probe works
 with JPEG photography; one sample is not a comparative benchmark.
 
 ## Reproduce
@@ -52,7 +52,11 @@ TMPDIR="$PWD/build/release/benchmark-fixtures" \
 The before comparison was built with the original `DetailSheet.qml` from
 `3f8703b`, plus the new `imageReady` property, while retaining this PR's tracing
 and other readiness checks. The after comparison uses the deferred player and
-output. See [metric definitions](../../../tests/README.md#performance).
+output. The `services` mark in the after samples is recorded immediately
+before QML loading, after image providers and context properties are
+registered. The before samples recorded it before that registration; the
+difference measured under 1 ms here and does not affect the table above.
+See [metric definitions](../../../tests/README.md#performance).
 
 ## Limits and remaining work
 

--- a/docs/performance/2026-09-05-startup/after.json
+++ b/docs/performance/2026-09-05-startup/after.json
@@ -1,0 +1,116 @@
+[
+  {
+    "mode": "single-image",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.841447,
+      "theme": 20.292118,
+      "services": 22.874905,
+      "qml": 83.499528,
+      "first_frame": 239.911743,
+      "image_frame": 268.107587
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 256928,
+    "peak_rss_kib": 256928
+  },
+  {
+    "mode": "single-image",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.653765,
+      "theme": 19.141022,
+      "services": 20.894861,
+      "qml": 78.676674,
+      "first_frame": 234.006192,
+      "image_frame": 259.871558
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 256996,
+    "peak_rss_kib": 256996
+  },
+  {
+    "mode": "single-image",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.420106,
+      "theme": 18.719417,
+      "services": 21.158212,
+      "qml": 76.740634,
+      "first_frame": 238.425231,
+      "image_frame": 253.726197
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 257060,
+    "peak_rss_kib": 257060
+  },
+  {
+    "mode": "library",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.52467,
+      "theme": 17.89412,
+      "services": 20.148664,
+      "qml": 69.428843,
+      "first_frame": 214.987966,
+      "grid_frame": 420.784315
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 256004,
+    "peak_rss_kib": 256004
+  },
+  {
+    "mode": "library",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 4.113206,
+      "theme": 21.329649,
+      "services": 23.014349,
+      "qml": 83.833678,
+      "first_frame": 262.465844,
+      "grid_frame": 492.528898
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 256524,
+    "peak_rss_kib": 256524
+  },
+  {
+    "mode": "library",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.710667,
+      "theme": 19.904885,
+      "services": 22.229587,
+      "qml": 77.090819,
+      "first_frame": 227.078627,
+      "grid_frame": 440.873605
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 256432,
+    "peak_rss_kib": 256432
+  }
+]

--- a/docs/performance/2026-09-05-startup/after.json
+++ b/docs/performance/2026-09-05-startup/after.json
@@ -3,114 +3,114 @@
     "mode": "single-image",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 3.841447,
-      "theme": 20.292118,
-      "services": 22.874905,
-      "qml": 83.499528,
-      "first_frame": 239.911743,
-      "image_frame": 268.107587
+      "application": 3.76173,
+      "theme": 19.287995,
+      "services": 21.296525,
+      "qml": 76.715962,
+      "first_frame": 229.454735,
+      "image_frame": 245.758953
     },
     "fixture": "transparent.png",
     "fixture_bytes": 749,
     "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
     "files": 100,
     "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 256928,
-    "peak_rss_kib": 256928
+    "rss_kib": 259920,
+    "peak_rss_kib": 259920
   },
   {
     "mode": "single-image",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 3.653765,
-      "theme": 19.141022,
-      "services": 20.894861,
-      "qml": 78.676674,
-      "first_frame": 234.006192,
-      "image_frame": 259.871558
+      "application": 3.745224,
+      "theme": 19.060328,
+      "services": 20.84897,
+      "qml": 73.609182,
+      "first_frame": 243.301354,
+      "image_frame": 265.439806
     },
     "fixture": "transparent.png",
     "fixture_bytes": 749,
     "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
     "files": 100,
     "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 256996,
-    "peak_rss_kib": 256996
+    "rss_kib": 260436,
+    "peak_rss_kib": 260436
   },
   {
     "mode": "single-image",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 3.420106,
-      "theme": 18.719417,
-      "services": 21.158212,
-      "qml": 76.740634,
-      "first_frame": 238.425231,
-      "image_frame": 253.726197
+      "application": 4.155414,
+      "theme": 21.059962,
+      "services": 23.089553,
+      "qml": 84.25053,
+      "first_frame": 232.872831,
+      "image_frame": 257.227589
     },
     "fixture": "transparent.png",
     "fixture_bytes": 749,
     "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
     "files": 100,
     "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 257060,
-    "peak_rss_kib": 257060
+    "rss_kib": 260888,
+    "peak_rss_kib": 260888
   },
   {
     "mode": "library",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 3.52467,
-      "theme": 17.89412,
-      "services": 20.148664,
-      "qml": 69.428843,
-      "first_frame": 214.987966,
-      "grid_frame": 420.784315
+      "application": 3.887104,
+      "theme": 20.370178,
+      "services": 22.348289,
+      "qml": 79.101409,
+      "first_frame": 247.285181,
+      "grid_frame": 471.867327
     },
     "fixture": "transparent.png",
     "fixture_bytes": 749,
     "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
     "files": 100,
     "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 256004,
-    "peak_rss_kib": 256004
+    "rss_kib": 258772,
+    "peak_rss_kib": 258772
   },
   {
     "mode": "library",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 4.113206,
-      "theme": 21.329649,
-      "services": 23.014349,
-      "qml": 83.833678,
-      "first_frame": 262.465844,
-      "grid_frame": 492.528898
+      "application": 3.830354,
+      "theme": 18.180418,
+      "services": 19.970937,
+      "qml": 77.87499,
+      "first_frame": 254.52669,
+      "grid_frame": 486.412222
     },
     "fixture": "transparent.png",
     "fixture_bytes": 749,
     "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
     "files": 100,
-    "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 256524,
-    "peak_rss_kib": 256524
+    "idle_cpu_percent_one_core": 0.1996288311920445,
+    "rss_kib": 258744,
+    "peak_rss_kib": 258744
   },
   {
     "mode": "library",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 3.710667,
-      "theme": 19.904885,
-      "services": 22.229587,
-      "qml": 77.090819,
-      "first_frame": 227.078627,
-      "grid_frame": 440.873605
+      "application": 3.696508,
+      "theme": 19.348544,
+      "services": 21.855226,
+      "qml": 77.233427,
+      "first_frame": 246.964606,
+      "grid_frame": 469.419281
     },
     "fixture": "transparent.png",
     "fixture_bytes": 749,
     "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
     "files": 100,
-    "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 256432,
-    "peak_rss_kib": 256432
+    "idle_cpu_percent_one_core": 0.19966454499568556,
+    "rss_kib": 259008,
+    "peak_rss_kib": 259008
   }
 ]

--- a/docs/performance/2026-09-05-startup/before.json
+++ b/docs/performance/2026-09-05-startup/before.json
@@ -1,0 +1,116 @@
+[
+  {
+    "mode": "single-image",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.417726,
+      "theme": 18.024933,
+      "services": 19.874882,
+      "qml": 799.808164,
+      "first_frame": 911.899711,
+      "image_frame": 927.251321
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 336592,
+    "peak_rss_kib": 336592
+  },
+  {
+    "mode": "single-image",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.25887,
+      "theme": 17.438285,
+      "services": 19.743084,
+      "qml": 824.182843,
+      "first_frame": 935.162493,
+      "image_frame": 949.917263
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 336432,
+    "peak_rss_kib": 336432
+  },
+  {
+    "mode": "single-image",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.929057,
+      "theme": 19.131998,
+      "services": 20.915064,
+      "qml": 810.278138,
+      "first_frame": 934.738078,
+      "image_frame": 950.608337
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 336420,
+    "peak_rss_kib": 336420
+  },
+  {
+    "mode": "library",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.823901,
+      "theme": 18.908487,
+      "services": 20.63342,
+      "qml": 836.745983,
+      "first_frame": 951.199919,
+      "grid_frame": 1169.575476
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 336468,
+    "peak_rss_kib": 336468
+  },
+  {
+    "mode": "library",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.590315,
+      "theme": 17.990588,
+      "services": 19.655961,
+      "qml": 837.560189,
+      "first_frame": 957.664418,
+      "grid_frame": 1181.206827
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 335932,
+    "peak_rss_kib": 335932
+  },
+  {
+    "mode": "library",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 4.241995,
+      "theme": 22.068505,
+      "services": 23.845069,
+      "qml": 900.630755,
+      "first_frame": 1003.416676,
+      "grid_frame": 1239.963419
+    },
+    "fixture": "transparent.png",
+    "fixture_bytes": 749,
+    "fixture_sha256": "9840c1cc71b4dee8b5285bb4021463336ed66d78560702bdc9e60d9e73b49e76",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 336024,
+    "peak_rss_kib": 336024
+  }
+]

--- a/docs/performance/2026-09-05-startup/photo.json
+++ b/docs/performance/2026-09-05-startup/photo.json
@@ -3,38 +3,38 @@
     "mode": "single-image",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 3.635587,
-      "theme": 19.472175,
-      "services": 21.44246,
-      "qml": 77.540491,
-      "first_frame": 238.173088,
-      "image_frame": 258.262549
+      "application": 3.669137,
+      "theme": 20.018315,
+      "services": 22.762163,
+      "qml": 77.07202,
+      "first_frame": 267.385411,
+      "image_frame": 287.377976
     },
     "fixture": "alpine-dawn.jpg",
     "fixture_bytes": 211749,
     "fixture_sha256": "04b8b2c33bb520c27ebf8781a9b686034d3fefeec528c9ad824307a2ebddd1b0",
     "files": 100,
     "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 283888,
-    "peak_rss_kib": 283888
+    "rss_kib": 289608,
+    "peak_rss_kib": 289608
   },
   {
     "mode": "library",
     "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
     "main_entry_stages_ms": {
-      "application": 3.561671,
-      "theme": 18.711665,
-      "services": 20.764967,
-      "qml": 71.074866,
-      "first_frame": 224.296897,
-      "grid_frame": 443.64381
+      "application": 4.227888,
+      "theme": 21.174106,
+      "services": 23.785227,
+      "qml": 84.292744,
+      "first_frame": 255.026307,
+      "grid_frame": 470.23651
     },
     "fixture": "alpine-dawn.jpg",
     "fixture_bytes": 211749,
     "fixture_sha256": "04b8b2c33bb520c27ebf8781a9b686034d3fefeec528c9ad824307a2ebddd1b0",
     "files": 100,
     "idle_cpu_percent_one_core": 0.0,
-    "rss_kib": 273276,
-    "peak_rss_kib": 273276
+    "rss_kib": 277020,
+    "peak_rss_kib": 277020
   }
 ]

--- a/docs/performance/2026-09-05-startup/photo.json
+++ b/docs/performance/2026-09-05-startup/photo.json
@@ -1,0 +1,40 @@
+[
+  {
+    "mode": "single-image",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.635587,
+      "theme": 19.472175,
+      "services": 21.44246,
+      "qml": 77.540491,
+      "first_frame": 238.173088,
+      "image_frame": 258.262549
+    },
+    "fixture": "alpine-dawn.jpg",
+    "fixture_bytes": 211749,
+    "fixture_sha256": "04b8b2c33bb520c27ebf8781a9b686034d3fefeec528c9ad824307a2ebddd1b0",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 283888,
+    "peak_rss_kib": 283888
+  },
+  {
+    "mode": "library",
+    "graphics": "NVIDIA Corporation RENDERER: NVIDIA GeForce RTX 4070 SUPER/PCIe/SSE2 VERSION: 4.6.0 NVIDIA 610.57.04",
+    "main_entry_stages_ms": {
+      "application": 3.561671,
+      "theme": 18.711665,
+      "services": 20.764967,
+      "qml": 71.074866,
+      "first_frame": 224.296897,
+      "grid_frame": 443.64381
+    },
+    "fixture": "alpine-dawn.jpg",
+    "fixture_bytes": 211749,
+    "fixture_sha256": "04b8b2c33bb520c27ebf8781a9b686034d3fefeec528c9ad824307a2ebddd1b0",
+    "files": 100,
+    "idle_cpu_percent_one_core": 0.0,
+    "rss_kib": 273276,
+    "peak_rss_kib": 273276
+  }
+]

--- a/docs/performance/2026-09-05/README.md
+++ b/docs/performance/2026-09-05/README.md
@@ -3,6 +3,9 @@
 Measured during multi-file opening development after 1.4.0. These are local
 engineering measurements, not release performance guarantees.
 
+The [startup follow-up](../2026-09-05-startup/README.md) adds content-ready
+frame measurements and compares eager and deferred video initialization.
+
 Environment: Intel Core i7-14700F, 28 logical CPUs, 31.1 GiB RAM,
 Linux 7.2.3-arch1-2, Qt 6.11.2, Release build. Disposable fixtures were placed
 on the project's Btrfs filesystem, not the RAM-backed `/tmp`. Filesystem caches

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -16,6 +16,17 @@ ApplicationWindow {
     // thumbnail is drawn opaque on top of it.
     color: "transparent"
 
+    // Called only by the opt-in startup trace, before scene synchronization.
+    // A decode failure is settled for slideshow purposes, but is not ready media.
+    function startupReadiness() {
+        if (modalOpen || popupOpen) return 0
+        if (detail.visible) {
+            return detail.imageReady && InitialPaths.length > 0
+                    && detail.path === InitialPaths[0] ? 2 : 0
+        }
+        return !Library.scanning && library.viewportReady() ? 4 : 0
+    }
+
     function shade(base, amount) {
         return Qt.rgba(base.r, base.g, base.b, amount)
     }

--- a/qml/components/CaptureCard.qml
+++ b/qml/components/CaptureCard.qml
@@ -23,6 +23,8 @@ Item {
     property bool selectionMode: false
     property string ocrSnippet: ""
     property bool thumbnailReady: false
+    readonly property bool thumbnailPresented: thumbnail.status === Image.Ready
+                                               && thumbnail.opacity >= 0.999
     // What leaves when this tile is dragged out. The grid sets it to the whole
     // selection when this tile is part of one.
     property var dragPaths: [path]

--- a/qml/components/CaptureGrid.qml
+++ b/qml/components/CaptureGrid.qml
@@ -29,6 +29,23 @@ FocusScope {
     signal deleteRequested(string path)
     signal detailRequested(int index)
 
+    // Include every intersecting cell, including the partial bottom row.
+    // Cached offscreen delegates do not count, nor does an empty library.
+    function viewportReady() {
+        if (!visible || !layoutReady || grid.count === 0 || grid.width <= 0 || grid.height <= 0)
+            return false
+        const firstRow = Math.max(0, Math.floor(grid.contentY / grid.cellHeight))
+        const lastRow = Math.ceil((grid.contentY + grid.height) / grid.cellHeight)
+        const first = firstRow * columns
+        const end = Math.min(grid.count, lastRow * columns)
+        if (first >= end) return false
+        for (let i = first; i < end; ++i) {
+            const cell = grid.itemAtIndex(i)
+            if (!cell || !cell.thumbnailPresented) return false
+        }
+        return true
+    }
+
     function shade(base, amount) {
         return Qt.rgba(base.r, base.g, base.b, amount)
     }
@@ -245,6 +262,7 @@ FocusScope {
 
         delegate: Item {
             id: cell
+            readonly property bool thumbnailPresented: card.thumbnailPresented
 
             required property int index
             required property string path
@@ -263,6 +281,7 @@ FocusScope {
             height: grid.cellHeight
 
             CaptureCard {
+                id: card
                 anchors.fill: parent
                 anchors.margins: Math.round(root.cellSpacing / 2)
 

--- a/qml/components/DetailSheet.qml
+++ b/qml/components/DetailSheet.qml
@@ -19,6 +19,11 @@ Item {
     property string timeLabel: ""
     property string sizeLabel: ""
     property bool isVideo: false
+    // Keep playback state after first use, but do not initialize the multimedia
+    // backend just to browse pictures. Loader creation is synchronous.
+    readonly property var player: playerLoader.item
+    readonly property var audio: player ? player.audioOutput : null
+    onIsVideoChanged: if (isVideo) playerLoader.active = true
     property bool isDocument: false
     property int pdfPage: 1
     property double stamp: 0
@@ -34,6 +39,10 @@ Item {
     property real imageSourceWidth: 0
     property real imageSourceHeight: 0
     property bool stillReady: false
+    readonly property bool imageReady: visible && !isVideo && !isDocument
+                                       && stillLoader.item !== null
+                                       && stillLoader.item.status === Image.Ready
+                                       && stillLoader.width > 0 && stillLoader.height > 0
     property bool fullScreen: false
     property bool showInfo: true
     property bool slideshowRunning: false
@@ -51,14 +60,14 @@ Item {
                                                                 : root.imageSourceHeight)
     readonly property string dimensionsLabel: root.mediaWidth > 0 && root.mediaHeight > 0
                                                ? root.mediaWidth + " × " + root.mediaHeight : ""
-    readonly property string durationLabel: root.isVideo && player.duration > 0
+    readonly property string durationLabel: root.isVideo && player && player.duration > 0
                                              ? root.formatDuration(player.duration) : ""
-    readonly property real playbackPosition: player.position
-    readonly property int playbackState: player.playbackState
-    readonly property real playbackRate: player.playbackRate
-    readonly property real playbackVolume: audio.volume
-    readonly property bool playbackMuted: audio.muted
-    readonly property int playbackLoops: player.loops
+    readonly property real playbackPosition: player ? player.position : 0
+    readonly property int playbackState: player ? player.playbackState : MediaPlayer.StoppedState
+    readonly property real playbackRate: player ? player.playbackRate : 1
+    readonly property real playbackVolume: audio ? audio.volume : 0.8
+    readonly property bool playbackMuted: audio ? audio.muted : false
+    readonly property int playbackLoops: player ? player.loops : 1
     readonly property bool isAnimatedImage: !root.isVideo && !root.isDocument
                                              && (root.fileName.toLowerCase().endsWith(".gif")
                                                  || root.fileName.toLowerCase().endsWith(".webp"))
@@ -515,7 +524,7 @@ Item {
                 asynchronous: true
                 smooth: true
                 mipmap: true
-                visible: root.isVideo && !player.hasVideo
+                visible: root.isVideo && !(player && player.hasVideo)
                 sourceSize: Qt.size(Math.round(stage.width * Screen.devicePixelRatio),
                                     Math.round(stage.height * Screen.devicePixelRatio))
                 source: root.path === "" ? ""
@@ -693,40 +702,45 @@ Item {
             // A recording plays in place with the normal controls expected of
             // a default media viewer. Specialist editing can still be handed
             // to the action list without weakening playback here.
-            MediaPlayer {
-                id: player
-                objectName: "videoPlayer"
-                source: root.visible && root.isVideo && root.path !== ""
-                        ? Library.fileUrl(root.path) : ""
-                videoOutput: output
-                audioOutput: AudioOutput {
-                    id: audio
-                    volume: 0.8
-                    muted: false
-                }
-                loops: 1
-                onSourceChanged: {
-                    if (source.toString() !== "") {
-                        play()
-                    }
-                }
-                // A clip the ffmpeg backend cannot decode must say so rather
-                // than sit behind a dead play button.
-                onErrorOccurred: function (error, errorString) {
-                    root.playbackError = errorString !== "" ? errorString : "Could not play this file"
-                    if (root.slideshowRunning) {
-                        slideshowErrorTimer.restart()
-                    }
-                }
-                onPositionChanged: {
-                    if (root.videoPausedForRender && player.position >= 1000
-                            && playbackState === MediaPlayer.PlayingState) {
-                        pause()
-                    }
-                }
-                onMediaStatusChanged: {
-                    if (mediaStatus === MediaPlayer.EndOfMedia && root.slideshowRunning) {
-                        root.requestNavigation(1)
+            Loader {
+                id: playerLoader
+                active: false
+                sourceComponent: Component {
+                    MediaPlayer {
+                        id: mediaPlayer
+                        objectName: "videoPlayer"
+                        source: root.visible && root.isVideo && root.path !== ""
+                                ? Library.fileUrl(root.path) : ""
+                        videoOutput: videoSurface.item
+                        audioOutput: AudioOutput {
+                            volume: 0.8
+                            muted: false
+                        }
+                        loops: 1
+                        onSourceChanged: {
+                            if (source.toString() !== "") {
+                                play()
+                            }
+                        }
+                        // A clip the ffmpeg backend cannot decode must say so rather
+                        // than sit behind a dead play button.
+                        onErrorOccurred: function (error, errorString) {
+                            root.playbackError = errorString !== "" ? errorString : "Could not play this file"
+                            if (root.slideshowRunning) {
+                                slideshowErrorTimer.restart()
+                            }
+                        }
+                        onPositionChanged: {
+                            if (root.videoPausedForRender && mediaPlayer.position >= 1000
+                                    && playbackState === MediaPlayer.PlayingState) {
+                                pause()
+                            }
+                        }
+                        onMediaStatusChanged: {
+                            if (mediaStatus === MediaPlayer.EndOfMedia && root.slideshowRunning) {
+                                root.requestNavigation(1)
+                            }
+                        }
                     }
                 }
             }
@@ -761,14 +775,27 @@ Item {
                 color: Theme.red
             }
 
-            VideoOutput {
+            Item {
                 id: output
-                objectName: "videoOutput"
                 anchors.fill: parent
                 anchors.margins: 16
                 anchors.bottomMargin: 56
-                fillMode: VideoOutput.PreserveAspectFit
-                visible: root.isVideo && player.hasVideo
+                visible: root.isVideo && player && player.hasVideo
+                readonly property rect sourceRect: videoSurface.item
+                                                   ? videoSurface.item.sourceRect : Qt.rect(0, 0, 0, 0)
+                readonly property QtObject videoSink: videoSurface.item ? videoSurface.item.videoSink : null
+
+                // VideoOutput creates a backend video sink even while hidden.
+                // Defer it alongside the player, preserving the stage geometry.
+                Loader {
+                    id: videoSurface
+                    anchors.fill: parent
+                    active: playerLoader.active
+                    sourceComponent: VideoOutput {
+                        objectName: "videoOutput"
+                        fillMode: VideoOutput.PreserveAspectFit
+                    }
+                }
 
                 TapHandler {
                     onDoubleTapped: root.setFullScreen(!root.fullScreen)
@@ -1031,8 +1058,8 @@ Item {
                     objectName: "videoPlayButton"
                     anchors.left: parent.left
                     anchors.verticalCenter: parent.verticalCenter
-                    label: player.playbackState === MediaPlayer.PlayingState ? "❚❚" : "▶"
-                    toolTip: player.playbackState === MediaPlayer.PlayingState ? "Pause" : "Play"
+                    label: root.playbackState === MediaPlayer.PlayingState ? "❚❚" : "▶"
+                    toolTip: root.playbackState === MediaPlayer.PlayingState ? "Pause" : "Play"
                     shortcut: "Space"
                     onClicked: root.toggleVideoPlayback()
                 }
@@ -1046,7 +1073,7 @@ Item {
                     anchors.verticalCenter: parent.verticalCenter
                     height: parent.height
 
-                    readonly property real fraction: player.duration > 0
+                    readonly property real fraction: player && player.duration > 0
                                                      ? player.position / player.duration : 0
 
                     Rectangle {
@@ -1069,7 +1096,7 @@ Item {
                     }
 
                     function seekTo(x) {
-                        if (player.duration > 0) {
+                        if (player && player.duration > 0) {
                             player.position = Math.max(0, Math.min(1, x / width)) * player.duration
                         }
                     }
@@ -1090,7 +1117,7 @@ Item {
                     anchors.right: mediaControls.left
                     anchors.rightMargin: 12
                     anchors.verticalCenter: parent.verticalCenter
-                    text: transport.clock(player.position) + " / " + transport.clock(player.duration)
+                    text: transport.clock(root.playbackPosition) + " / " + transport.clock(player ? player.duration : 0)
                     font.family: Theme.fontFamily
                     font.pixelSize: 11
                     color: Theme.mutedText
@@ -1103,36 +1130,36 @@ Item {
                     spacing: 6
 
                     PillButton {
-                        visible: player.audioTracks.length > 1 && transport.width >= 520
-                        label: "Audio " + (player.activeAudioTrack + 1)
+                        visible: player && player.audioTracks.length > 1 && transport.width >= 520
+                        label: "Audio " + (player ? player.activeAudioTrack + 1 : 1)
                         toolTip: "Switch audio track"
                         onClicked: root.cycleAudioTrack()
                     }
                     PillButton {
-                        visible: player.subtitleTracks.length > 0 && transport.width >= 440
+                        visible: player && player.subtitleTracks.length > 0 && transport.width >= 440
                         objectName: "subtitleButton"
                         label: "CC"
-                        toolTip: player.activeSubtitleTrack >= 0
+                        toolTip: player && player.activeSubtitleTrack >= 0
                                  ? "Turn subtitles off" : "Choose subtitles"
-                        active: player.activeSubtitleTrack >= 0
+                        active: player && player.activeSubtitleTrack >= 0
                         onClicked: root.cycleSubtitleTrack()
                     }
                     PillButton {
                         id: speedButton
                         objectName: "playbackSpeedButton"
-                        label: Number(player.playbackRate.toFixed(2)) + "×"
+                        label: Number(root.playbackRate.toFixed(2)) + "×"
                         toolTip: "Playback speed"
                         shortcut: "[  ]"
-                        active: Math.abs(player.playbackRate - 1) > 0.01
+                        active: Math.abs(root.playbackRate - 1) > 0.01
                         onClicked: root.cyclePlaybackRate()
                     }
                     PillButton {
                         id: soundButton
                         objectName: "videoSoundButton"
-                        label: audio.muted ? "Muted" : Math.round(audio.volume * 100) + "%"
-                        toolTip: audio.muted ? "Unmute" : "Mute"
+                        label: root.playbackMuted ? "Muted" : Math.round(root.playbackVolume * 100) + "%"
+                        toolTip: root.playbackMuted ? "Unmute" : "Mute"
                         shortcut: "M"
-                        active: !audio.muted
+                        active: !root.playbackMuted
                         onClicked: audio.muted = !audio.muted
                     }
                 }
@@ -1169,7 +1196,7 @@ Item {
 
             Rectangle {
                 id: slideshowVideoProgress
-                visible: root.isVideo && root.slideshowRunning && player.duration > 0
+                visible: root.isVideo && root.slideshowRunning && player && player.duration > 0
                 anchors.left: parent.left
                 anchors.right: topControlsPanel.left
                 anchors.leftMargin: 16
@@ -1181,7 +1208,8 @@ Item {
                 color: root.shade(Theme.foreground, 0.14)
 
                 Rectangle {
-                    width: parent.width * Math.max(0, Math.min(1, player.position / player.duration))
+                    width: player && player.duration > 0
+                           ? parent.width * Math.max(0, Math.min(1, player.position / player.duration)) : 0
                     height: parent.height
                     radius: parent.radius
                     color: root.shade(Theme.accent, 0.78)

--- a/src/app/StartupTrace.h
+++ b/src/app/StartupTrace.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <QDebug>
+#include <QElapsedTimer>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QQuickWindow>
+#include <QVariant>
+
+#include <atomic>
+#include <memory>
+#include <utility>
+
+// Opt-in developer diagnostics. No paths or media contents are logged.
+class StartupTrace {
+public:
+  StartupTrace() : m_enabled(qEnvironmentVariableIntValue("OMAROLL_STARTUP_TRACE") == 1) {
+    if (m_enabled) {
+      m_clock.start();
+    }
+  }
+
+  void mark(const char* stage) const {
+    if (m_enabled) {
+      const QJsonObject event{{QStringLiteral("stage"), QString::fromLatin1(stage)},
+                              {QStringLiteral("elapsed_ms"), m_clock.nsecsElapsed() / 1e6}};
+      qInfo().noquote() << "OMAROLL_STARTUP"
+                       << QJsonDocument(event).toJson(QJsonDocument::Compact);
+    }
+  }
+
+  void watch(QQuickWindow* window) const {
+    if (!m_enabled || !window) {
+      return;
+    }
+    struct State {
+      std::atomic<int> ready{0};
+      int synchronized = 0;
+      int reported = 0;
+    };
+    auto state = std::make_shared<State>();
+    // Read QML on the GUI thread, then latch that snapshot during scene sync.
+    // A later GUI update must not label an earlier frame as containing media.
+    QObject::connect(window, &QQuickWindow::afterAnimating, window, [window, state] {
+      QVariant ready;
+      if (QMetaObject::invokeMethod(window, "startupReadiness", Q_RETURN_ARG(QVariant, ready))) {
+        state->ready.store(ready.toInt());
+      }
+    });
+    QObject::connect(window, &QQuickWindow::beforeSynchronizing, window, [state] {
+      state->synchronized = state->ready.load();
+    }, Qt::DirectConnection);
+    QObject::connect(window, &QQuickWindow::afterFrameEnd, window, [trace = *this, state] {
+      const int frame = state->synchronized | 1;
+      for (const auto& [bit, name] : {std::pair{1, "first_frame"},
+                                     std::pair{2, "image_frame"},
+                                     std::pair{4, "grid_frame"}}) {
+        if ((frame & bit) && !(state->reported & bit)) {
+          trace.mark(name);
+          state->reported |= bit;
+        }
+      }
+    }, Qt::DirectConnection);
+  }
+
+private:
+  bool m_enabled;
+  QElapsedTimer m_clock;
+};

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -387,7 +387,6 @@ int main(int argc, char* argv[]) {
   QObject::connect(&actions, &ActionLauncher::outputSettled, &captures, &CaptureModel::releasePath);
 
   QQmlApplicationEngine engine;
-  startup.mark("services");
   auto* thumbnailProvider = new ThumbnailProvider;
   auto* matteProvider = new MatteProvider;
   auto* pdfProvider = new PdfProvider;
@@ -424,6 +423,7 @@ int main(int argc, char* argv[]) {
       &engine, &QQmlApplicationEngine::objectCreationFailed, &application,
       [] { QCoreApplication::exit(1); }, Qt::QueuedConnection);
 
+  startup.mark("services");
   engine.loadFromModule("Omaroll", "Main");
   startup.mark("qml");
   if (engine.rootObjects().isEmpty()) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -6,6 +6,7 @@
 #include "app/HeadlessAudio.h"
 #include "app/OpenRequest.h"
 #include "app/SingleInstance.h"
+#include "app/StartupTrace.h"
 #include "library/CaptureFilterModel.h"
 #include "library/CaptureModel.h"
 #include "library/DuplicateIndex.h"
@@ -155,6 +156,7 @@ Options:
 } // namespace
 
 int main(int argc, char* argv[]) {
+  const StartupTrace startup;
   QGuiApplication::setApplicationName(QStringLiteral("Omaroll"));
   QGuiApplication::setApplicationDisplayName(QStringLiteral("Omaroll"));
   QGuiApplication::setApplicationVersion(QStringLiteral(OMAROLL_VERSION));
@@ -207,6 +209,7 @@ int main(int argc, char* argv[]) {
   }
 
   QGuiApplication application(argc, argv);
+  startup.mark("application");
   QIcon applicationIcon = QIcon::fromTheme(QStringLiteral("io.github.tsouth89.omaroll"));
   if (applicationIcon.isNull()) {
     applicationIcon = QIcon(QStringLiteral(":/icons/resources/icons/omaroll.svg"));
@@ -302,6 +305,7 @@ int main(int argc, char* argv[]) {
   }
 
   OmarchyTheme theme;
+  startup.mark("theme");
   AppSettings settings;
   if (demo) {
     settings.setSlideshowVideos(true);
@@ -383,6 +387,7 @@ int main(int argc, char* argv[]) {
   QObject::connect(&actions, &ActionLauncher::outputSettled, &captures, &CaptureModel::releasePath);
 
   QQmlApplicationEngine engine;
+  startup.mark("services");
   auto* thumbnailProvider = new ThumbnailProvider;
   auto* matteProvider = new MatteProvider;
   auto* pdfProvider = new PdfProvider;
@@ -420,9 +425,11 @@ int main(int argc, char* argv[]) {
       [] { QCoreApplication::exit(1); }, Qt::QueuedConnection);
 
   engine.loadFromModule("Omaroll", "Main");
+  startup.mark("qml");
   if (engine.rootObjects().isEmpty()) {
     return 1;
   }
+  startup.watch(qobject_cast<QQuickWindow*>(engine.rootObjects().constFirst()));
 
   if (!rendering && !demo) {
     auto* window = qobject_cast<QQuickWindow*>(engine.rootObjects().constFirst());

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,14 +80,35 @@ and twenty cold-cache then warm-cache thumbnails. Peak memory belongs to the
 benchmark process, which also creates fixtures; it is not application memory.
 
 The startup probe launches the actual executable six times using offscreen Qt
-and OpenGL, recording the actual graphics driver. The software-rendering
-environment request is not honored by every driver. Each launch gets fresh
-application settings and a fresh thumbnail cache, with 100 copies of the transparent PNG fixture. It
-records receipt of Qt's first completed scene-graph rendering log after the
-renderer has done work, then samples idle CPU between seconds three and eight.
-This is a diagnostic first-frame measurement. It does not establish when the
-requested image or useful grid becomes visible. Zero measured idle CPU means
-no CPU ticks were observed during that short interval.
+and OpenGL, recording the actual graphics driver. Each launch gets fresh
+settings and a fresh thumbnail cache, with 100 copies of the transparent PNG.
+Use `--fixture resources/demo/alpine-dawn.jpg` to measure a photographic image,
+`--files N` to change the library size, and `--runs N` for repeated samples.
+Fixture creation is excluded. The output records the fixture hash and size.
+
+`OMAROLL_STARTUP_TRACE=1` enables diagnostic JSON lines on stderr. Timings start
+at entry to `main`, excluding process spawning and dynamic loading before main:
+
+- `application`, `theme`, `services`, `qml`: cumulative setup milestones.
+- `first_frame`: first scene-graph frame submitted.
+- `image_frame`: frame submitted after the requested still image reports a
+  successful decode and has nonzero display dimensions.
+- `grid_frame`: frame submitted after scanning settles and every cell
+  intersecting the viewport has a decoded thumbnail at full opacity. An empty
+  library, missing delegate, failed decode or fading thumbnail does not qualify.
+
+Readiness is sampled on the GUI thread before scene synchronization, latched
+at synchronization, then reported at Qt's
+[afterFrameEnd](https://doc.qt.io/qt-6/qquickwindow.html#afterFrameEnd) signal.
+These are content-ready submitted frames, not pixel readbacks or proof of
+presentation by Hyprland. The UI tests separately exercise failed images,
+thumbnail fading and rendered media. Normal launches do not enable tracing.
+
+The probe fails if required milestones are absent within its eight-second
+observation window. CI checks that evidence arrives and retains the JSON; it
+sets no speed threshold. Idle CPU is sampled between seconds three and eight.
+Zero means no CPU ticks were observed in that interval. Do not run benchmarks
+concurrently with builds or other tests.
 
 Use `xvfb-run -a` around the startup command on headless CI hosts that need an
 X display for Mesa. These measurements are informational, not CI timing gates.

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,21 +19,22 @@ does not block Qt's native PipeWire backend.
 ## Rendered video
 
 Qt's software scene graph can decode video without displaying it. Run the
-OpenGL suite as well. On a headless Arch machine, install `imagemagick`, `mesa`,
+OpenGL suite as well. In a disposable headless Arch CI container, install `imagemagick`, `mesa`,
 `xorg-server-xvfb` and `xorg-xauth`, then run:
 
 ```sh
 xvfb-run -a bash tests/run-opengl.sh build/release
 ```
 
-With a working local display, run it inside the local audio sandbox:
+On the development desktop, always run it inside the local audio sandbox:
 
 ```sh
 bash tests/run-isolated.sh build/release bash tests/run-opengl.sh build/release
 ```
 
 It uses
-offscreen Qt and software OpenGL, uses the disconnected audio backend, runs the full
+offscreen Qt and requests software OpenGL (some drivers use hardware instead),
+uses the disconnected audio backend, runs the full
 UI suite and renders narrow grid, video and OCR views. The video-track test
 requires actual colored pixels in the rendered video area. Inspect the PNGs in
 `build/release/opengl-renders/` for layout changes.
@@ -114,6 +115,9 @@ Use `xvfb-run -a` around the startup command on headless CI hosts that need an
 X display for Mesa. These measurements are informational, not CI timing gates.
 Wayland presentation, cold disk reads, large photographs, animation and warm
 viewer navigation require separate measurements.
+
+The [startup follow-up](../docs/performance/2026-09-05-startup/README.md) records
+content-ready timing and the deferred-video comparison.
 
 A [recorded development baseline](../docs/performance/2026-09-05/README.md)
 includes raw results and the measurements still outstanding.

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,6 +91,8 @@ Fixture creation is excluded. The output records the fixture hash and size.
 at entry to `main`, excluding process spawning and dynamic loading before main:
 
 - `application`, `theme`, `services`, `qml`: cumulative setup milestones.
+  `services` is recorded after image providers and context properties are
+  registered, immediately before QML loading.
 - `first_frame`: first scene-graph frame submitted.
 - `image_frame`: frame submitted after the requested still image reports a
   successful decode and has nonzero display dimensions.

--- a/tests/benchmark_startup.py
+++ b/tests/benchmark_startup.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Measure a real executable's first scene-graph frame and idle resource use.
+"""Measure startup stages, media-ready frames and idle resource use.
 
-Offscreen OpenGL, with the actual driver recorded. First frame does not prove the image or grid is ready.
+Offscreen OpenGL, with the actual driver recorded. Frames are submitted, not compositor-presented.
 No personal files, settings, cache, instance socket or physical audio are used.
 """
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -20,14 +21,14 @@ def cpu_seconds(pid):
     return (int(fields[11]) + int(fields[12])) / os.sysconf("SC_CLK_TCK")
 
 
-def sample(binary, fixture, mode):
+def sample(binary, fixture, mode, file_count=100):
     with tempfile.TemporaryDirectory(prefix="omaroll-benchmark-") as root:
         scratch = Path(root)
         pictures = scratch / "Pictures"
         pictures.mkdir()
         (scratch / "empty").mkdir()
-        for index in range(100):
-            shutil.copyfile(fixture, pictures / f"image{index}.png")
+        for index in range(file_count):
+            shutil.copyfile(fixture, pictures / f"image{index}{fixture.suffix}")
         env = dict(os.environ)
         for name in ("HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"):
             env[name] = str(scratch / name)
@@ -40,15 +41,14 @@ def sample(binary, fixture, mode):
                    LIBGL_ALWAYS_SOFTWARE="1", QT_AUDIO_BACKEND="pulseaudio",
                    PULSE_SERVER="unix:/nonexistent", PIPEWIRE_REMOTE="omaroll-no-audio",
                    WAYLAND_DISPLAY=scratch.name, QT_FORCE_STDERR_LOGGING="1",
-                   QSG_RENDER_TIMING="1", QSG_INFO="1")
+                   OMAROLL_STARTUP_TRACE="1", QSG_INFO="1")
         args = [str(binary)]
         if mode == "single-image":
-            args.append(str(pictures / "image0.png"))
+            args.append(str(pictures / f"image0{fixture.suffix}"))
         started = time.perf_counter()
         process = subprocess.Popen(args, env=env, stdout=subprocess.DEVNULL,
                                    stderr=subprocess.PIPE)
-        first_frame = None
-        scene_seen = False
+        stages = {}
         graphics = None
         idle_start = None
         pending = b""
@@ -67,18 +67,22 @@ def sample(binary, fixture, mode):
                         for line in lines:
                             if b"OpenGL VENDOR: " in line:
                                 graphics = line.split(b"OpenGL VENDOR: ", 1)[1].decode(errors="replace")
-                            if b"time in renderer: total=" in line:
-                                scene_seen = True
-                            if scene_seen and first_frame is None and b"frame rendered in" in line:
-                                first_frame = (time.perf_counter() - started) * 1000
+                            if b"OMAROLL_STARTUP " in line:
+                                event = json.loads(line.split(b"OMAROLL_STARTUP ", 1)[1])
+                                stages[event["stage"]] = event["elapsed_ms"]
                 idle_cpu = cpu_seconds(process.pid) - idle_start[1]
                 idle_wall = time.perf_counter() - idle_start[0]
                 status = Path(f"/proc/{process.pid}/status").read_text().splitlines()
                 memory = {line.split(":")[0]: int(line.split()[1])
                           for line in status if line.startswith(("VmRSS:", "VmHWM:"))}
-                if first_frame is None or graphics is None:
-                    raise RuntimeError("No scene-graph render timing received; check Mesa and Qt logging")
-                return dict(mode=mode, graphics=graphics, first_scene_frame_ms=first_frame,
+                expected = "image_frame" if mode == "single-image" else "grid_frame"
+                required = {"application", "theme", "services", "qml", "first_frame", expected}
+                if required - stages.keys() or graphics is None:
+                    raise RuntimeError(f"Missing startup evidence: {required - stages.keys()}; graphics={graphics}")
+                return dict(mode=mode, graphics=graphics, main_entry_stages_ms=stages,
+                            fixture=fixture.name, fixture_bytes=fixture.stat().st_size,
+                            fixture_sha256=hashlib.sha256(fixture.read_bytes()).hexdigest(),
+                            files=file_count,
                             idle_cpu_percent_one_core=100 * idle_cpu / idle_wall,
                             rss_kib=memory["VmRSS"], peak_rss_kib=memory["VmHWM"])
         finally:
@@ -95,11 +99,18 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("binary", type=Path)
     parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--fixture", type=Path,
+                        default=Path(__file__).parent / "fixtures/viewer/transparent.png",
+                        help="Still image to copy into the disposable library")
+    parser.add_argument("--files", type=int, default=100)
     args = parser.parse_args()
     if not 1 <= args.runs <= 20:
         parser.error("--runs must be 1..20")
-    fixture = Path(__file__).parent / "fixtures/viewer/transparent.png"
-    results = [sample(args.binary.resolve(), fixture, mode)
+    if not 1 <= args.files <= 10000:
+        parser.error("--files must be 1..10000")
+    if not args.fixture.is_file():
+        parser.error("--fixture must be an existing image")
+    results = [sample(args.binary.resolve(), args.fixture.resolve(), mode, args.files)
                for mode in ("single-image", "library") for _ in range(args.runs)]
     print(json.dumps(results, indent=2))
 

--- a/tests/tst_ui.cpp
+++ b/tests/tst_ui.cpp
@@ -61,6 +61,7 @@
 #include <QtTest>
 
 #include <functional>
+#include <algorithm>
 
 class UiTest : public QObject {
   Q_OBJECT
@@ -155,7 +156,15 @@ private slots:
     m_engine = new QQmlApplicationEngine(this);
     connect(m_engine, &QQmlEngine::warnings, this, [this](const QList<QQmlError>& warnings) {
       for (const QQmlError& warning : warnings) {
-        m_warnings.append(warning.toString());
+        const auto expected = std::find_if(m_expectedQmlWarnings.begin(), m_expectedQmlWarnings.end(),
+                                          [&](const QString& suffix) {
+                                            return warning.toString().endsWith(suffix);
+                                          });
+        if (expected != m_expectedQmlWarnings.end()) {
+          m_expectedQmlWarnings.erase(expected);
+        } else {
+          m_warnings.append(warning.toString());
+        }
       }
     });
     m_engine->addImportPath(QStringLiteral(OMAROLL_QML_IMPORT_PATH));
@@ -196,6 +205,8 @@ private slots:
     QTRY_VERIFY_WITH_TIMEOUT(m_library->rowCount() >= 3, 15000);
     // Let the grid lay its tiles out before anything is clicked.
     QTRY_VERIFY_WITH_TIMEOUT(cardFor(pathAt(1)) != nullptr, 5000);
+    QVERIFY(!m_window->findChild<QMediaPlayer*>(QStringLiteral("videoPlayer")));
+    QVERIFY(!m_window->findChild<QObject*>(QStringLiteral("videoOutput")));
   }
 
   void cleanupTestCase() {
@@ -327,6 +338,39 @@ private slots:
     QCOMPARE(detail->property("path").toString(), shown);
   }
 
+  void startupReadinessExcludesPlaceholdersAndFailedImages() {
+    QQuickItem* grid = item("library");
+    const auto viewportReady = [grid] {
+      QVariant ready;
+      QMetaObject::invokeMethod(grid, "viewportReady", Q_RETURN_ARG(QVariant, ready));
+      return ready.toBool();
+    };
+    QTRY_VERIFY_WITH_TIMEOUT(viewportReady(), 15000);
+    QQuickItem* card = cardFor(pathAt(0));
+    QVERIFY(card);
+    // A decoded thumbnail which is still faded out is not a useful tile.
+    card->setProperty("thumbnailReady", false);
+    QTRY_VERIFY(!card->property("thumbnailPresented").toBool());
+    QVERIFY(!viewportReady());
+    card->setProperty("thumbnailReady", true);
+    QTRY_VERIFY(viewportReady());
+
+    openDetail(m_library->rowOf(QFileInfo(m_oddPath).canonicalFilePath()));
+    QQuickItem* detail = item("detail");
+    QTRY_VERIFY(detail->property("imageReady").toBool());
+    const QString missing = m_scratch.filePath(QStringLiteral("missing-image.png"));
+    // Consume exactly the two decoder warnings this negative case provokes.
+    m_expectedQmlWarnings = {QStringLiteral("Cannot open: ") + QUrl::fromLocalFile(missing).toString(),
+                             QStringLiteral("No thumbnail for ") + missing};
+    detail->setProperty("path", missing);
+    QTRY_VERIFY(!detail->property("playbackError").toString().isEmpty());
+    QVERIFY(detail->property("stillReady").toBool());
+    QVERIFY(!detail->property("imageReady").toBool());
+    QTRY_VERIFY(m_expectedQmlWarnings.isEmpty());
+    invoke("dismissTopLayer");
+    QVERIFY(!detail->property("imageReady").toBool());
+  }
+
   void imageViewerSupportsActualSizeFlipsDeepZoomAndAnimationPause() {
     int imageRow = -1;
     for (int row = 0; row < m_library->rowCount(); ++row) {
@@ -424,6 +468,22 @@ private slots:
     QTRY_VERIFY(detail->property("fullScreen").toBool());
     QTest::mouseDClick(m_window, Qt::LeftButton, Qt::NoModifier, centre(output));
     QTRY_VERIFY(!detail->property("fullScreen").toBool());
+
+    // Closing and visiting a picture must stop decoding, but retain the player
+    // and its session controls when the next video is opened.
+    auto* player = m_window->findChild<QMediaPlayer*>(QStringLiteral("videoPlayer"));
+    QVERIFY(player);
+    const double retainedVolume = detail->property("playbackVolume").toDouble();
+    invoke("dismissTopLayer");
+    openDetail(m_library->rowOf(QFileInfo(m_oddPath).canonicalFilePath()));
+    QTRY_VERIFY(detail->property("imageReady").toBool());
+    QTRY_VERIFY(player->source().isEmpty());
+    QCOMPARE(player->playbackState(), QMediaPlayer::StoppedState);
+    invoke("dismissTopLayer");
+    openDetail(videoRow);
+    QCOMPARE(m_window->findChild<QMediaPlayer*>(QStringLiteral("videoPlayer")), player);
+    QTRY_COMPARE(player->playbackState(), QMediaPlayer::PlayingState);
+    QCOMPARE(detail->property("playbackVolume").toDouble(), retainedVolume);
   }
 
   void rightClickOnATileOpensThatTile() {
@@ -1791,6 +1851,7 @@ private:
   QQmlApplicationEngine* m_engine = nullptr;
   QQuickWindow* m_window = nullptr;
   QStringList m_warnings;
+  QStringList m_expectedQmlWarnings;
   QString m_oddPath;
   QString m_pdfPath;
 };


### PR DESCRIPTION
Opening images or the library now defers the video player and display until the first video is opened. They remain available afterward, preserving session playback controls.

Adds startup measurements that distinguish the first window frame from a decoded image or fully loaded viewport. CI records these timings without setting a speed threshold. [Local before/after results](https://github.com/btsouth/omaroll/blob/79f59fcb115a9fff553b05f3117d7bb9e3497125/docs/performance/2026-09-05-startup/README.md).

Validation:

- 88 core checks and 52 UI checks pass.
- AddressSanitizer, UndefinedBehaviorSanitizer and OpenGL rendering checks pass.
- Isolated startup probes pass with PNG and JPEG fixtures, including a sanitizer run.

[Project status and handoff](https://github.com/btsouth/omaroll/blob/1b5ecb209c8e8566372a6e7680956f4f9cf419e6/docs/STATUS.md) records release boundaries, remaining acceptance gates and the next work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Startup is faster for image viewing and library browsing by deferring video setup until a video is opened.
  * Video playback remains available when needed, with playback controls preserved across navigation.

* **Documentation**
  * Added guidance for selecting files in a specified order, including handling hidden and removed files.
  * Updated build, testing, release, and project-status documentation.

* **Testing**
  * Expanded startup, rendering, video, and thumbnail-readiness validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->