### PR TITLE
Prepare Omaroll 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,24 @@
 # Changelog
 
-## Unreleased
+## 1.5.0
 
-- Defer video setup until a video is opened, reducing startup work for images and the library.
+### Added
 
-- Keep automated playback and headless renders off physical audio devices, including native PipeWire.
+- Open multiple selected files in order, including across folders and in an
+  already-running window. Explicitly selected hidden files open without
+  scanning their surrounding folders.
+- Opt-in startup readiness tracing and a reproducible startup benchmark.
 
-- Open multiple selected files in order, including across folders and in an already-running window.
-- Open explicitly selected hidden files without scanning their surrounding folders.
+### Changed
 
-- Sort numbered filenames naturally, so image2 appears before image10.
-- Confirm copying extracted text visually and through accessibility announcements.
-- Run real video rendering checks under Mesa OpenGL in CI and release validation.
+- Video setup is deferred until a video is opened, reducing startup work for
+  images and the library.
+- Numbered filenames sort naturally, so image2 appears before image10.
+- Copying extracted text is confirmed visually and through accessibility
+  announcements.
+- Real video rendering checks run under Mesa OpenGL in CI and release
+  validation, and automated playback stays off physical audio devices,
+  including native PipeWire.
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - Thumbnail, PDF and matte image responses no longer risk a crash when a
   request is cancelled or finishes during fast scrolling or a tile size change.
+- Tiles no longer keep a previous file's thumbnail after the window or tile
+  size changes, which could open a different file than the one shown.
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   validation, and automated playback stays off physical audio devices,
   including native PipeWire.
 
+### Fixed
+
+- Thumbnail, PDF and matte image responses no longer risk a crash when a
+  request is cancelled or finishes during fast scrolling or a tile size change.
+
 ## 1.4.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(Omaroll VERSION 1.4.0 LANGUAGES CXX)
+project(Omaroll VERSION 1.5.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -205,10 +205,10 @@ Documents: PDF. Thumbnails, previews, and page counts use Poppler locally.
 Requires Omarchy or Arch with Qt 6.8+ and Poppler.
 
 ```bash
-curl -fLO https://github.com/btsouth/omaroll/releases/download/v1.4.0/omaroll-1.4.0-1-x86_64.pkg.tar.zst \
-     -fLO https://github.com/btsouth/omaroll/releases/download/v1.4.0/SHA256SUMS
+curl -fLO https://github.com/btsouth/omaroll/releases/download/v1.5.0/omaroll-1.5.0-1-x86_64.pkg.tar.zst \
+     -fLO https://github.com/btsouth/omaroll/releases/download/v1.5.0/SHA256SUMS
 sha256sum -c --ignore-missing SHA256SUMS
-sudo pacman -U ./omaroll-1.4.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./omaroll-1.5.0-1-x86_64.pkg.tar.zst
 ```
 
 Run the same commands for a newer release to update. The package is prepared for
@@ -242,7 +242,7 @@ You can also choose Omaroll from a file manager's **Open With** menu and set it
 as the default for the media types you want. A single file opens directly in the
 viewer, with previous and next navigation through other media in that folder.
 
-Current main also supports ordered file selections (unreleased since 1.4.0):
+Several files can be opened together, in the order given:
 
 ```bash
 omaroll first.jpg ~/Pictures/second.png third.webp

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing Omaroll
 
-Start with [current status](docs/STATUS.md). v1.4.0 is the latest release in the
-5 September 2026 handoff. Merged work and draft PR #6 do not constitute a new
-release; no next version has been selected.
+Start with [current status](docs/STATUS.md). v1.4.0 is the latest published
+release. Version 1.5.0 is prepared in the tree and is released only when its
+tag is pushed after desktop acceptance.
 
 1. Update the version in `CMakeLists.txt`, AppStream metadata, the changelog,
    README package command, and public feature descriptions.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,6 @@ See [current status and handoff](STATUS.md) for release boundaries and evidence.
   already running in CI. Local tests stay audio-isolated.
 - Verify installed behavior on Omarchy: file-manager opening, scaling,
   clipboard, drag/drop, window state and physical audio.
-- Review draft PR #6 for deferred video setup and content-ready startup timing.
 - Extend recorded startup and 10k/50k library baselines with warm navigation,
   larger/mixed libraries, compositor presentation and regression budgets.
 - Maintain the [Omarchy package submission](https://github.com/omacom/omarchy-pkgs/pull/295).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Project status and handoff
 
-Snapshot: 5 September 2026 UTC, after PR #8 merged. Check the linked PRs and release before resuming.
+Snapshot: 5 September 2026 UTC, after PR #9 merged. Check the linked PRs and release before resuming.
 
 ## Released
 
@@ -27,6 +27,10 @@ Main carries the 1.5.0 version, changelog and AppStream entry. It bundles:
   emit `finished()` on their own thread, fixing a use-after-free that the
   pixmap reader's `deleteLater()` could trigger while the pool thread was
   still unwinding the emit.
+- [PR #9](https://github.com/btsouth/omaroll/pull/9): grid delegates are
+  rebuilt rather than reused across the tile relayout, fixing tiles that kept
+  a previous file's thumbnail and opened a different file in small tiled
+  windows. Found in the desktop test of the 1.5.0 candidate.
 
 CodeRabbit reviewed PR #6 with one minor finding, which was fixed before the
 squash merge. Core, UI, sanitizer and OpenGL checks passed locally and in CI.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,39 +1,33 @@
 # Project status and handoff
 
-Snapshot: 5 September 2026 UTC. Check the linked PRs and release before resuming.
+Snapshot: 5 September 2026 UTC, after PR #6 merged. Check the linked PRs and release before resuming.
 
 ## Released
 
 [v1.4.0](https://github.com/btsouth/omaroll/releases/tag/v1.4.0) remains the latest
-public release. No newer tag or package was published during this session.
+public release. 1.5.0 is prepared but not tagged or published.
 The viewer supports still and animated images, embedded video controls, PDF
 paging, OCR/QR, albums, tags, saved collections and duplicate review. The
 README describes the supported formats and workflows.
 
-## Merged, awaiting a release
+## Prepared: 1.5.0, not yet tagged
 
-Main is at `3f8703b` in this snapshot:
+Main carries the 1.5.0 version, changelog and AppStream entry. It bundles:
 
 - [PR #3](https://github.com/btsouth/omaroll/pull/3): home-directory wrapper cleanup.
 - [PR #4](https://github.com/btsouth/omaroll/pull/4): natural filename sorting,
   accessible OCR copy feedback and rendered media checks in CI/release validation.
 - [PR #5](https://github.com/btsouth/omaroll/pull/5): ordered multi-file opening,
   selection forwarding to an existing window, performance baselines and isolated
-  media tests. Selected files remain discoverable after supported file actions.
+  media tests.
+- [PR #6](https://github.com/btsouth/omaroll/pull/6): deferred video player and
+  display until a video is opened, plus startup readiness tracing and a
+  benchmark probe. The first video still pays the initialization cost.
 
-## Open for review
-
-[Draft PR #6](https://github.com/btsouth/omaroll/pull/6), branch
-`codex/startup-readiness`, defers both the video player and display until a video
-is opened. It also measures a decoded image or fully loaded viewport followed
-by frame submission. The first video still pays the initialization cost.
-
-Application changes are committed at `79f59fc`. At that commit, 88 core checks,
-52 UI checks, ASan/UBSan, OpenGL rendering and GitHub CI/CodeQL passed. The
-startup probe also passed under sanitizers and in CI on Mesa llvmpipe.
-CodeRabbit skipped review because the PR is a draft; automated checks are not
-a human review. The documentation handoff follows in the same PR. Check CI on
-its latest head before merging.
+CodeRabbit reviewed PR #6 with one minor finding, which was fixed before the
+squash merge. Core, UI, sanitizer and OpenGL checks passed locally and in CI.
+One intermittent SIGSEGV in `omaroll_ui_tests` occurred once locally and did
+not reproduce in three reruns; its core dump is unexplained.
 
 [Local measurements](performance/2026-09-05-startup/README.md) record medians
 of 949.9 to 257.2 ms for an image-ready submitted frame and 1181.2 to 471.9 ms
@@ -42,8 +36,9 @@ not compositor presentation or general performance guarantees.
 
 ## Next decisions and release gates
 
-1. Review PR #6 and address feedback. Leave it open until review and merge are
-   explicitly requested. Keep subsequent changes in separate focused PRs.
+1. Try the 1.5.0 candidate on the real Omarchy desktop, then tag `v1.5.0`
+   following [RELEASING.md](../RELEASING.md). Keep new changes in separate
+   focused PRs.
 2. Finish installed Omarchy acceptance (SBS-1121): file-manager selections,
    clipboard, drag/drop, scaling, window state and physical audio. Headless
    passes do not close this gate.
@@ -53,8 +48,7 @@ not compositor presentation or general performance guarantees.
    copy, collision handling and a metadata/color policy. Reuse Omarchy helpers
    where they satisfy the workflow. Comparison and organization improvements
    follow in the [roadmap](ROADMAP.md).
-5. Choose and validate the next release only after review and acceptance.
-   Follow [RELEASING.md](../RELEASING.md); no new version is selected yet.
+5. After 1.5.0 ships, refresh the Omarchy package submission to it.
 
 [Official package PR #295](https://github.com/omacom/omarchy-pkgs/pull/295)
 remains open and targets v1.4.0. Earlier edge, rc and stable package builds
@@ -75,7 +69,8 @@ video tracks and subtitles. No media downloads are needed for those checks.
 Physical audio testing remains a deliberate desktop acceptance activity.
 
 Linear is the active task tracker. Access it through Toolport. SBS-1093 is the
-parent roadmap; SBS-1125 is done, while SBS-1121 and SBS-1122 remain in progress.
+parent roadmap; SBS-1121 and SBS-1122 remain in progress, and SBS-1126 is the
+next feature to start.
 Notes under `build/roadmap-review/` are historical and ignored by Git. This
 file is the committed handoff. No further implementation, merge or release
 work is scheduled by closing this session.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Project status and handoff
 
-Snapshot: 5 September 2026 UTC, after PR #6 merged. Check the linked PRs and release before resuming.
+Snapshot: 5 September 2026 UTC, after PR #8 merged. Check the linked PRs and release before resuming.
 
 ## Released
 
@@ -23,11 +23,15 @@ Main carries the 1.5.0 version, changelog and AppStream entry. It bundles:
 - [PR #6](https://github.com/btsouth/omaroll/pull/6): deferred video player and
   display until a video is opened, plus startup readiness tracing and a
   benchmark probe. The first video still pays the initialization cost.
+- [PR #8](https://github.com/btsouth/omaroll/pull/8): async image responses
+  emit `finished()` on their own thread, fixing a use-after-free that the
+  pixmap reader's `deleteLater()` could trigger while the pool thread was
+  still unwinding the emit.
 
 CodeRabbit reviewed PR #6 with one minor finding, which was fixed before the
 squash merge. Core, UI, sanitizer and OpenGL checks passed locally and in CI.
-One intermittent SIGSEGV in `omaroll_ui_tests` occurred once locally and did
-not reproduce in three reruns; its core dump is unexplained.
+The intermittent SIGSEGV in `omaroll_ui_tests` seen once on 2026-09-04 was
+traced through its core dump to the response lifetime race fixed in PR #8.
 
 [Local measurements](performance/2026-09-05-startup/README.md) record medians
 of 949.9 to 257.2 ms for an image-ready submitted frame and 1181.2 to 471.9 ms

--- a/packaging/io.github.tsouth89.omaroll.metainfo.xml
+++ b/packaging/io.github.tsouth89.omaroll.metainfo.xml
@@ -37,6 +37,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.5.0" date="2026-09-05"/>
     <release version="1.4.0" date="2026-09-04"/>
     <release version="1.3.1" date="2026-09-03"/>
     <release version="1.3.0" date="2026-09-03"/>


### PR DESCRIPTION
Bumps the version to 1.5.0, adds the AppStream release entry, moves the unreleased changelog into a 1.5.0 section, updates the README install command and refreshes the status handoff after PR #6 merged.

Release build, core/UI tests, OpenGL render checks and metadata validation pass locally. Nothing is tagged; the tag waits for a pass on the real Omarchy desktop.