### PR TITLE
Emit image response finished() on the response thread

### DIFF
--- a/src/matte/MatteProvider.cpp
+++ b/src/matte/MatteProvider.cpp
@@ -3,6 +3,7 @@
 #include "matte/MatteComposer.h"
 
 #include <QImageReader>
+#include <QMetaObject>
 #include <QRunnable>
 #include <QThread>
 #include <QUrl>
@@ -32,10 +33,19 @@ public:
 
   void cancel() override { m_cancelled.store(true); }
 
+  // Qt's pixmap reader deletes the response with deleteLater() as soon as
+  // finished() reaches it, and the response lives on the reader thread.
+  // Emitting straight from the pool thread lets that deletion land while the
+  // emit is still unwinding, which is a use-after-free. Posting the emit to the
+  // response's own thread serializes it with the deletion.
+  void finishOnOwnThread() {
+    QMetaObject::invokeMethod(this, [this] { emit finished(); }, Qt::QueuedConnection);
+  }
+
   void run() override {
     if (m_cancelled.load()) {
       m_error = QStringLiteral("Cancelled");
-      emit finished();
+      finishOnOwnThread();
       return;
     }
     QImageReader reader(m_path);
@@ -54,7 +64,7 @@ public:
     const QImage source = reader.read();
     if (source.isNull()) {
       m_error = QStringLiteral("Could not read %1").arg(m_path);
-      emit finished();
+      finishOnOwnThread();
       return;
     }
 
@@ -63,7 +73,7 @@ public:
                                static_cast<MatteComposer::Aspect>(m_aspect), m_padding);
     if (composed.isNull()) {
       m_error = QStringLiteral("Could not compose a matte");
-      emit finished();
+      finishOnOwnThread();
       return;
     }
 
@@ -73,7 +83,7 @@ public:
     }
 
     m_image = composed;
-    emit finished();
+    finishOnOwnThread();
   }
 
 private:

--- a/src/pdf/PdfProvider.cpp
+++ b/src/pdf/PdfProvider.cpp
@@ -2,6 +2,7 @@
 
 #include "pdf/PdfSupport.h"
 
+#include <QMetaObject>
 #include <QRunnable>
 #include <QThread>
 #include <QUrl>
@@ -20,17 +21,26 @@ public:
   }
   QString errorString() const override { return m_error; }
   void cancel() override { m_cancelled.store(true); }
+
+  // Qt's pixmap reader deletes the response with deleteLater() as soon as
+  // finished() reaches it, and the response lives on the reader thread.
+  // Emitting straight from the pool thread lets that deletion land while the
+  // emit is still unwinding, which is a use-after-free. Posting the emit to the
+  // response's own thread serializes it with the deletion.
+  void finishOnOwnThread() {
+    QMetaObject::invokeMethod(this, [this] { emit finished(); }, Qt::QueuedConnection);
+  }
   void run() override {
     if (m_cancelled.load()) {
       m_error = QStringLiteral("Cancelled");
-      emit finished();
+      finishOnOwnThread();
       return;
     }
     m_image = PdfSupport::renderPage(m_path, m_page, m_target);
     if (m_image.isNull()) {
       m_error = QStringLiteral("Could not render PDF page");
     }
-    emit finished();
+    finishOnOwnThread();
   }
 
 private:

--- a/src/thumbs/ThumbnailProvider.cpp
+++ b/src/thumbs/ThumbnailProvider.cpp
@@ -2,6 +2,7 @@
 
 #include "thumbs/ThumbnailCache.h"
 
+#include <QMetaObject>
 #include <QRunnable>
 #include <QThread>
 #include <QUrl>
@@ -33,10 +34,19 @@ public:
   // that are still on screen.
   void cancel() override { m_cancelled.store(true); }
 
+  // Qt's pixmap reader deletes the response with deleteLater() as soon as
+  // finished() reaches it, and the response lives on the reader thread.
+  // Emitting straight from the pool thread lets that deletion land while the
+  // emit is still unwinding, which is a use-after-free. Posting the emit to the
+  // response's own thread serializes it with the deletion.
+  void finishOnOwnThread() {
+    QMetaObject::invokeMethod(this, [this] { emit finished(); }, Qt::QueuedConnection);
+  }
+
   void run() override {
     if (m_cancelled.load()) {
       m_error = QStringLiteral("Cancelled");
-      emit finished();
+      finishOnOwnThread();
       return;
     }
     m_image = ThumbnailCache::thumbnail(m_path, m_logicalSize, m_devicePixelRatio, m_seekPercent);
@@ -46,7 +56,7 @@ public:
       // let the delegate show its placeholder.
       m_error = QStringLiteral("No thumbnail for %1").arg(m_path);
     }
-    emit finished();
+    finishOnOwnThread();
   }
 
 private:


### PR DESCRIPTION
omaroll_ui_tests segfaulted once during tileSizeFollowsControlPlusAndMinus with a QThreadPool worker crashing in QObjectPrivate::ConnectionData::cleanOrphanedConnections. The core shows a ThumbnailResponse being destroyed while its own finished() emit was still unwinding on the pool thread.

The cause is how the three async image responses signal completion. Qt's pixmap reader connects to finished(), and the response lives on the reader thread. The reader calls deleteLater() on the response as soon as the queued signal arrives, so if the worker thread has not yet returned from doActivate the last few lines of the emit read freed memory. Changing tile size cancels every in-flight thumbnail and each cancelled run() emits almost immediately, which is why that test hit it. The same pattern is in MatteProvider and PdfProvider and can hit users during a fast scroll.

The fix posts the emit to the response's own thread with a queued QMetaObject::invokeMethod, matching how the Qt image response example emits finished() from a slot rather than from the runnable. The pool thread no longer touches the object after posting, and Qt drops the queued call if the response is destroyed first.

Tested with tests/run-isolated.sh: full suite passes, plus ten isolated runs of the tile, thumbnail, PDF and matte tests and three full UI suite runs with no crashes. The race did not reproduce on demand before the fix either, so the core dump is the evidence rather than the reruns.
