### PR TITLE
Cycle the sections with Tab and Shift+Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Tab and Shift+Tab step through the sections, wrapping at either end.
+
 ## 1.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ and put on your clipboard.
 | `N` | Rename, preserving the extension |
 | `Y` · `S` · `F` | Clipboard · Send · Show in files |
 | `V` · `Ctrl+H` | Favourite · Hide |
-| `1`-`8` | Jump to a section |
+| `1`-`8` · `Tab` `Shift+Tab` | Jump to a section · next · previous section |
 | `Page Up` `Page Down` in a PDF preview | Previous · next page |
 | `X` · `Ctrl+A` | Select · Select all |
 | with a selection | `V` `Ctrl+H` `Y` `S` `Del` act on every checked file |

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1435,6 +1435,19 @@ ApplicationWindow {
             }
         }
     }
+    // Tab walks the sections the way it walks tabs in a browser. The window
+    // owns it, so it does not traverse the pills; those keep the number keys
+    // and the mouse. The search field, sheets and menus own their own Tab.
+    Shortcut {
+        sequences: ["Tab"]
+        enabled: !root.anySheetOpen && !root.popupOpen && !filters.searchActive
+        onActivated: filters.cycleSection(1)
+    }
+    Shortcut {
+        sequences: ["Shift+Tab", "Backtab", "Shift+Backtab"]
+        enabled: !root.anySheetOpen && !root.popupOpen && !filters.searchActive
+        onActivated: filters.cycleSection(-1)
+    }
     Shortcut {
         sequences: ["Ctrl+A"]
         enabled: !root.anySheetOpen

--- a/qml/components/FilterBar.qml
+++ b/qml/components/FilterBar.qml
@@ -36,6 +36,18 @@ Item {
 
     function sectionShortcut(index) { return String(index + 1) }
 
+    // Tab walks the sections in the order the pills show them and wraps.
+    // Favourites is orthogonal to the kind and stays out of the cycle.
+    function cycleSection(step) {
+        const kinds = [kindAll, kindScreenshot, kindRecording, kindPicture, kindVideo,
+                       kindDocument]
+        if (Settings.scanDownloads) {
+            kinds.splice(5, 0, kindDownload)
+        }
+        const current = Math.max(0, kinds.indexOf(Captures.kindFilter))
+        Captures.kindFilter = kinds[(current + step + kinds.length) % kinds.length]
+    }
+
     readonly property var sortLabels: ["Newest", "Oldest", "Largest", "Smallest", "Name"]
 
     // True while the search field owns the keyboard, so window-level

--- a/tests/tst_ui.cpp
+++ b/tests/tst_ui.cpp
@@ -693,6 +693,50 @@ private slots:
     QTRY_VERIFY(!m_library->property("favoritesOnly").toBool());
   }
 
+  void tabCyclesTheSectionsAndWraps() {
+    QTest::keyClick(m_window, Qt::Key_1);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), -1);
+    QTest::keyClick(m_window, Qt::Key_Tab);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), 0);
+    QTest::keyClick(m_window, Qt::Key_Tab);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), 1);
+    QTest::keyClick(m_window, Qt::Key_Tab, Qt::ShiftModifier);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), 0);
+    QTest::keyClick(m_window, Qt::Key_Backtab, Qt::ShiftModifier);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), -1);
+    // Backwards from All wraps to the last section, PDFs.
+    QTest::keyClick(m_window, Qt::Key_Backtab, Qt::ShiftModifier);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), 5);
+    QTest::keyClick(m_window, Qt::Key_Tab);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), -1);
+
+    // Downloads joins the cycle only while it is scanned.
+    const bool downloads = m_settings->scanDownloads();
+    m_settings->setScanDownloads(true);
+    QTest::keyClick(m_window, Qt::Key_5);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), 3);
+    QTest::keyClick(m_window, Qt::Key_Tab);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), 4);
+    m_settings->setScanDownloads(false);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), -1);
+    QTest::keyClick(m_window, Qt::Key_5);
+    QTest::keyClick(m_window, Qt::Key_Tab);
+    QTRY_COMPARE(m_library->property("kindFilter").toInt(), 5);
+    m_settings->setScanDownloads(downloads);
+
+    // The search field keeps Tab for itself.
+    QTest::keyClick(m_window, Qt::Key_1);
+    QTest::keyClick(m_window, Qt::Key_Slash);
+    QTRY_VERIFY(item("filters")->property("searchActive").toBool());
+    QTest::keyClick(m_window, Qt::Key_Tab);
+    QTest::qWait(50);
+    QCOMPARE(m_library->property("kindFilter").toInt(), -1);
+    // Tab has traversed out of the field, so hand the grid its focus back
+    // rather than sending an Escape that would now close the window.
+    item("library")->forceActiveFocus();
+    QTRY_VERIFY(item("library")->hasActiveFocus());
+  }
+
   void exactDuplicatesOpenAsAGroupedReviewView() {
     QObject* browser = m_window->findChild<QObject*>(QStringLiteral("libraryBrowser"));
     QVERIFY(browser);


### PR DESCRIPTION
Tab steps forward through the section pills (All, Screenshots, Recordings, Pictures, Videos, Downloads, PDFs) and Shift+Tab steps back, wrapping at either end. Downloads only joins the cycle while it is scanned. The number keys still jump straight to a section and Favourites stays a separate toggle.

The shortcut is window level and stands down while a sheet, a menu or the search field owns the keyboard, so the detail sheet and the search field keep their own Tab handling.

Adds a UI test covering forward, backward, wrap, the Downloads toggle and the search field guard. README and changelog updated.

Linear: SBS-1138
