### PR TITLE
Index camera and lens metadata for Browse filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 - Tab and Shift+Tab step through the sections, wrapping at either end.
+- Browse a photo library by camera and lens. The metadata pass that reads
+  capture dates now records the camera and lens too, and saved views keep
+  the choice. Libraries without camera photos do not show the section.
 
 ## 1.5.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ add_library(omaroll_core STATIC
   src/library/MediaInspector.h
   src/library/SimilarityIndex.cpp
   src/library/SimilarityIndex.h
-  src/library/MediaDateIndex.cpp
-  src/library/MediaDateIndex.h
+  src/library/MediaMetadataIndex.cpp
+  src/library/MediaMetadataIndex.h
   src/sources/CaptureScanner.cpp
   src/sources/CaptureScanner.h
   src/sources/CaptureLocations.cpp

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ on them.
 - **Saves useful views.** Any combination of search, kind, folder, date, tag,
   favourites, hidden files, and sort order can become a smart collection that
   updates as files change.
+- **Browses by camera.** Photos and videos with embedded camera details can
+  be filtered by camera or lens from Browse, and a saved view remembers the
+  choice. A library of screenshots never shows the section.
 - **Adds lightweight tags.** Tag any selection and browse it without moving or
   copying files. Tags follow in-app renames and can be combined with saved views.
 - **Knows what each file is.** Omarchy stamps its captures with a predictable

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -306,6 +306,8 @@ ApplicationWindow {
         Captures.similarOnly = false
         Captures.clearDateRange()
         Captures.setTagFilter("", [])
+        Captures.cameraFilter = ""
+        Captures.lensFilter = ""
         Captures.clearSmartCollection()
         Captures.setAlbumFilter("", [])
         Captures.folderFilter = folder === undefined ? "" : folder
@@ -593,11 +595,11 @@ ApplicationWindow {
                     if (library.checkedCount > 0) {
                         return library.checkedCount + " selected"
                     }
-                    if (MediaDates.indexing) {
-                        return MediaDates.total > 0
-                               ? "Reading media dates · " + MediaDates.completed
-                                 + " of " + MediaDates.total
-                               : "Reading media dates…"
+                    if (MediaMetadata.indexing) {
+                        return MediaMetadata.total > 0
+                               ? "Reading media details · " + MediaMetadata.completed
+                                 + " of " + MediaMetadata.total
+                               : "Reading media details…"
                     }
                     if (Captures.count === 0) {
                         return "Nothing to show"

--- a/qml/components/CaptureGrid.qml
+++ b/qml/components/CaptureGrid.qml
@@ -223,7 +223,7 @@ FocusScope {
         displaced: Transition {
             NumberAnimation {
                 properties: "x,y"
-                duration: MediaDates.indexing ? 0 : 200
+                duration: MediaMetadata.indexing ? 0 : 200
                 easing.type: Easing.OutQuad
             }
         }

--- a/qml/components/FilterBar.qml
+++ b/qml/components/FilterBar.qml
@@ -158,6 +158,8 @@ Item {
                       : Captures.similarOnly ? "Similar pictures  ▾"
                       : Captures.smartCollectionFilter !== "" ? Captures.smartCollectionFilter + "  ▾"
                       : Captures.tagFilter !== "" ? "#" + Captures.tagFilter + "  ▾"
+                      : Captures.cameraFilter !== "" ? Captures.cameraFilter + "  ▾"
+                      : Captures.lensFilter !== "" ? Captures.lensFilter + "  ▾"
                       : Captures.dateFrom !== "" || Captures.modifiedAfter !== "" ? "Date  ▾"
                       : Captures.albumFilter !== "" ? Captures.albumFilter + "  ▾"
                       : Captures.folderFilter !== ""
@@ -165,6 +167,7 @@ Item {
             active: Captures.folderFilter !== "" || Captures.albumFilter !== ""
                     || Captures.duplicatesOnly
                     || Captures.similarOnly || Captures.tagFilter !== ""
+                    || Captures.cameraFilter !== "" || Captures.lensFilter !== ""
                     || Captures.dateFrom !== "" || Captures.modifiedAfter !== ""
                     || Captures.smartCollectionFilter !== ""
                     || root.browserOpen

--- a/qml/components/LibraryBrowserSheet.qml
+++ b/qml/components/LibraryBrowserSheet.qml
@@ -21,10 +21,26 @@ FocusScope {
         }
         return rows
     }
+    // Cameras first, then lenses, each most used first. Rows carry their
+    // type so one list can filter on either field.
+    readonly property var cameraChoices: {
+        const rows = []
+        for (const camera of Captures.cameras) {
+            rows.push({type: "camera", value: camera.name, label: camera.name,
+                       count: camera.count})
+        }
+        for (const lens of Captures.lenses) {
+            rows.push({type: "lens", value: lens.name, label: lens.name, count: lens.count})
+        }
+        return rows
+    }
+    readonly property bool hasCameras: Captures.cameras.length > 0
+                                       || Captures.lenses.length > 0
     readonly property var sourceChoices: section === 0 ? Captures.folders
                                          : section === 1 ? Settings.albumNames
                                          : section === 2 ? dateChoices
                                          : section === 3 ? Settings.tagNames
+                                         : section === 5 ? cameraChoices
                                          : Settings.smartCollectionNames
     readonly property var filteredChoices: {
         if (query === "") {
@@ -57,6 +73,7 @@ FocusScope {
         section = Captures.albumFilter !== "" ? 1
                   : Captures.dateFrom !== "" || Captures.modifiedAfter !== "" ? 2
                   : Captures.tagFilter !== "" ? 3
+                  : Captures.cameraFilter !== "" || Captures.lensFilter !== "" ? 5
                   : Captures.smartCollectionFilter !== "" ? 4 : 0
         folderSearch.text = ""
         query = ""
@@ -76,6 +93,8 @@ FocusScope {
         Captures.folderFilter = ""
         Captures.setAlbumFilter("", [])
         Captures.setTagFilter("", [])
+        Captures.cameraFilter = ""
+        Captures.lensFilter = ""
         Captures.clearDateRange()
         Captures.clearSmartCollection()
     }
@@ -118,6 +137,16 @@ FocusScope {
     function showTag(name) {
         clearLibraryView()
         Captures.setTagFilter(name, Settings.tagPaths(name))
+        close()
+    }
+
+    function showCamera(choice) {
+        clearLibraryView()
+        if (choice.type === "lens") {
+            Captures.lensFilter = String(choice.value)
+        } else {
+            Captures.cameraFilter = String(choice.value)
+        }
         close()
     }
 
@@ -180,7 +209,9 @@ FocusScope {
         const selected = section === 0 ? Captures.folderFilter
                          : section === 1 ? Captures.albumFilter
                          : section === 3 ? Captures.tagFilter
-                         : section === 4 ? Captures.smartCollectionFilter : ""
+                         : section === 4 ? Captures.smartCollectionFilter
+                         : section === 5 ? (Captures.cameraFilter !== ""
+                                            ? Captures.cameraFilter : Captures.lensFilter) : ""
         if (selected !== "") {
             for (let index = 0; index < filteredChoices.length; index++) {
                 const choice = filteredChoices[index]
@@ -217,12 +248,14 @@ FocusScope {
         else if (section === 1) showAlbum(String(choice))
         else if (section === 2) showDate(choice)
         else if (section === 3) showTag(String(choice))
+        else if (section === 5) showCamera(choice)
         else showSmart(String(choice))
     }
 
     function deleteCurrentChoice() {
         const index = choices.currentIndex
-        if (index < 0 || index >= choices.count || section === 0 || section === 2) {
+        if (index < 0 || index >= choices.count || section === 0 || section === 2
+                || section === 5) {
             return
         }
         const name = String(choices.model[index])
@@ -307,7 +340,9 @@ FocusScope {
 
             Text {
                 width: parent.width
-                text: "Browse folders, dates, albums, tags, saved views, and review sets."
+                text: root.hasCameras
+                      ? "Browse folders, dates, albums, tags, cameras, saved views, and review sets."
+                      : "Browse folders, dates, albums, tags, saved views, and review sets."
                 wrapMode: Text.WordWrap
                 font.family: Theme.fontFamily
                 font.pixelSize: 11
@@ -322,6 +357,7 @@ FocusScope {
                     active: Captures.folderFilter === "" && Captures.albumFilter === ""
                             && Captures.tagFilter === "" && Captures.dateFrom === ""
                             && Captures.dateTo === "" && Captures.modifiedAfter === ""
+                            && Captures.cameraFilter === "" && Captures.lensFilter === ""
                             && Captures.smartCollectionFilter === ""
                             && !Captures.duplicatesOnly && !Captures.similarOnly
                     onClicked: root.showAll()
@@ -435,6 +471,14 @@ FocusScope {
                     onClicked: { root.section = 3; folderSearch.forceActiveFocus() }
                 }
                 PillButton {
+                    // Only a library with photos from a real camera earns this
+                    // section; a screenshot library never sees it.
+                    visible: root.hasCameras || root.section === 5
+                    label: "Cameras  " + root.formatCount(Captures.cameras.length)
+                    active: root.section === 5
+                    onClicked: { root.section = 5; folderSearch.forceActiveFocus() }
+                }
+                PillButton {
                     label: "Smart  " + root.formatCount(Settings.smartCollectionNames.length)
                     active: root.section === 4
                     onClicked: { root.section = 4; folderSearch.forceActiveFocus() }
@@ -507,7 +551,9 @@ FocusScope {
                     text: root.section === 0 ? "Find a folder"
                           : root.section === 1 ? "Find an album"
                           : root.section === 2 ? "Find a date"
-                          : root.section === 3 ? "Find a tag" : "Find a smart collection"
+                          : root.section === 3 ? "Find a tag"
+                          : root.section === 5 ? "Find a camera or lens"
+                                               : "Find a smart collection"
                     font.family: Theme.fontFamily
                     font.pixelSize: 12
                     color: root.shade(Theme.foreground, 0.35)
@@ -533,6 +579,7 @@ FocusScope {
                           : root.section === 1 ? "No matching albums"
                           : root.section === 2 ? "No matching dates"
                           : root.section === 3 ? "No matching tags"
+                          : root.section === 5 ? "No matching cameras or lenses"
                                                : "No matching smart collections"
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -546,22 +593,27 @@ FocusScope {
                     required property var modelData
                     required property int index
                     readonly property bool dateChoice: root.section === 2
-                    readonly property string value: dateChoice ? String(modelData.value)
-                                                                    : String(modelData)
-                    readonly property string choiceLabel: dateChoice ? String(modelData.label)
-                                                                          : value
+                    readonly property bool cameraChoice: root.section === 5
+                    readonly property bool objectChoice: dateChoice || cameraChoice
+                    readonly property string value: objectChoice ? String(modelData.value)
+                                                                      : String(modelData)
+                    readonly property string choiceLabel: objectChoice ? String(modelData.label)
+                                                                            : value
                     readonly property bool selectedChoice:
                         root.section === 0 ? Captures.folderFilter === value
                         : root.section === 1 ? Captures.albumFilter === value
                         : root.section === 2 ? Captures.dateFrom === String(modelData.from)
                                              && Captures.dateTo === String(modelData.to)
                         : root.section === 3 ? Captures.tagFilter === value
+                        : root.section === 5 ? (modelData.type === "lens"
+                                                ? Captures.lensFilter === value
+                                                : Captures.cameraFilter === value)
                                              : Captures.smartCollectionFilter === value
                     readonly property int itemCount: root.section === 0
                                                      ? Captures.folderItemCount(value)
                                                      : root.section === 1
                                                      ? Settings.albumPaths(value).length
-                                                     : root.section === 2 ? Number(modelData.count)
+                                                     : objectChoice ? Number(modelData.count)
                                                      : root.section === 3
                                                      ? Settings.tagItemCount(value) : 0
                     width: choices.width - 10
@@ -598,7 +650,11 @@ FocusScope {
                                     + root.formatCount(choiceRow.itemCount)
                                     + (choiceRow.itemCount === 1 ? " item" : " items")
                                   : root.section === 4 ? "Dynamic saved view"
-                                  : root.formatCount(choiceRow.itemCount)
+                                  : (choiceRow.cameraChoice
+                                     ? (choiceRow.modelData.type === "lens" ? "Lens  ·  "
+                                                                            : "Camera  ·  ")
+                                     : "")
+                                    + root.formatCount(choiceRow.itemCount)
                                     + (choiceRow.itemCount === 1 ? " item" : " items")
                             elide: Text.ElideMiddle
                             font.family: Theme.fontFamily

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -10,7 +10,7 @@
 #include "library/CaptureFilterModel.h"
 #include "library/CaptureModel.h"
 #include "library/DuplicateIndex.h"
-#include "library/MediaDateIndex.h"
+#include "library/MediaMetadataIndex.h"
 #include "library/MediaInspector.h"
 #include "library/SimilarityIndex.h"
 #include "matte/MatteComposer.h"
@@ -324,7 +324,7 @@ int main(int argc, char* argv[]) {
   CaptureModel captures(&settings);
   // Demo and render order is deliberately fixed. Real libraries are enriched
   // in the background after their fast filesystem scan lands.
-  MediaDateIndex mediaDates(demo ? nullptr : &captures);
+  MediaMetadataIndex mediaMetadata(demo ? nullptr : &captures);
 
   // QML only ever sees the proxy, so sorting and filtering can change without
   // any delegate knowing.
@@ -413,7 +413,7 @@ int main(int argc, char* argv[]) {
   engine.rootContext()->setContextProperty(QStringLiteral("Similarities"), &similarities);
   engine.rootContext()->setContextProperty(QStringLiteral("MediaInfo"), &mediaInfo);
   engine.rootContext()->setContextProperty(QStringLiteral("PdfInfo"), &pdfInfo);
-  engine.rootContext()->setContextProperty(QStringLiteral("MediaDates"), &mediaDates);
+  engine.rootContext()->setContextProperty(QStringLiteral("MediaMetadata"), &mediaMetadata);
   engine.rootContext()->setContextProperty(QStringLiteral("Tailscale"), &tailscale);
   engine.rootContext()->setContextProperty(QStringLiteral("DemoMode"), demo);
   engine.rootContext()->setContextProperty(QStringLiteral("InitialPaths"), request.files);

--- a/src/library/CaptureFilterModel.cpp
+++ b/src/library/CaptureFilterModel.cpp
@@ -36,11 +36,15 @@ CaptureFilterModel::CaptureFilterModel(QObject* parent) : QSortFilterProxyModel(
   connect(&m_folderIndexTimer, &QTimer::timeout, this, [this] {
     const bool folderIndexChanged = rebuildFolderIndex();
     const bool datesChanged = rebuildDateIndex();
+    const bool camerasChanged = rebuildCameraIndex();
     if (folderIndexChanged) {
       emit foldersChanged();
     }
     if (datesChanged) {
       emit dateBucketsChanged();
+    }
+    if (camerasChanged) {
+      emit this->camerasChanged();
     }
   });
   m_duplicateOrderTimer.setSingleShot(true);
@@ -80,6 +84,9 @@ void CaptureFilterModel::setSourceModel(QAbstractItemModel* model) {
     m_dateBuckets.clear();
     m_dateDays.clear();
     emit dateBucketsChanged();
+    m_cameras.clear();
+    m_lenses.clear();
+    emit camerasChanged();
     return;
   }
 
@@ -116,7 +123,9 @@ void CaptureFilterModel::setSourceModel(QAbstractItemModel* model) {
                   m_folderIndexTimer.start();
                 }
                 if (roles.isEmpty() || roles.contains(CaptureRoles::CapturedRole) ||
-                    roles.contains(CaptureRoles::StampRole)) {
+                    roles.contains(CaptureRoles::StampRole) ||
+                    roles.contains(CaptureRoles::CameraRole) ||
+                    roles.contains(CaptureRoles::LensRole)) {
                   m_folderIndexTimer.start();
                 }
                 if ((!m_duplicateGroups.isEmpty() || !m_similarGroups.isEmpty()) &&
@@ -129,8 +138,10 @@ void CaptureFilterModel::setSourceModel(QAbstractItemModel* model) {
               }));
   (void)rebuildFolderIndex();
   (void)rebuildDateIndex();
+  (void)rebuildCameraIndex();
   emit foldersChanged();
   emit dateBucketsChanged();
+  emit camerasChanged();
 }
 
 void CaptureFilterModel::beginFilterUpdate() {
@@ -445,6 +456,77 @@ QVariantList CaptureFilterModel::dateDays(const QString& monthKey) const {
   return m_dateDays.value(monthKey);
 }
 
+namespace {
+
+QVariantList countedChoices(const QHash<QString, int>& counts) {
+  QStringList names = counts.keys();
+  std::sort(names.begin(), names.end(), [&counts](const QString& a, const QString& b) {
+    if (counts.value(a) != counts.value(b)) {
+      return counts.value(a) > counts.value(b);
+    }
+    return a.compare(b, Qt::CaseInsensitive) < 0;
+  });
+  QVariantList rows;
+  rows.reserve(names.size());
+  for (const QString& name : std::as_const(names)) {
+    QVariantMap row;
+    row.insert(QStringLiteral("name"), name);
+    row.insert(QStringLiteral("count"), counts.value(name));
+    rows.append(row);
+  }
+  return rows;
+}
+
+} // namespace
+
+bool CaptureFilterModel::rebuildCameraIndex() {
+  QHash<QString, int> cameraCounts;
+  QHash<QString, int> lensCounts;
+  if (sourceModel()) {
+    for (int row = 0; row < sourceModel()->rowCount(); ++row) {
+      const CaptureRecord& record = sourceRecord(row);
+      if (!record.camera.isEmpty()) {
+        ++cameraCounts[record.camera];
+      }
+      if (!record.lens.isEmpty()) {
+        ++lensCounts[record.lens];
+      }
+    }
+  }
+  QVariantList cameras = countedChoices(cameraCounts);
+  QVariantList lenses = countedChoices(lensCounts);
+  if (cameras == m_cameras && lenses == m_lenses) {
+    return false;
+  }
+  m_cameras = std::move(cameras);
+  m_lenses = std::move(lenses);
+  return true;
+}
+
+void CaptureFilterModel::setCameraFilter(const QString& camera) {
+  if (m_cameraFilter == camera) {
+    return;
+  }
+  beginFilterUpdate();
+  m_cameraFilter = camera;
+  endFilterUpdate();
+  clearSmartCollection();
+  emit cameraFilterChanged();
+  emit countChanged();
+}
+
+void CaptureFilterModel::setLensFilter(const QString& lens) {
+  if (m_lensFilter == lens) {
+    return;
+  }
+  beginFilterUpdate();
+  m_lensFilter = lens;
+  endFilterUpdate();
+  clearSmartCollection();
+  emit lensFilterChanged();
+  emit countChanged();
+}
+
 QVariantMap CaptureFilterModel::currentView() const {
   QVariantMap view;
   view.insert(QStringLiteral("search"), m_searchText);
@@ -457,6 +539,8 @@ QVariantMap CaptureFilterModel::currentView() const {
   view.insert(QStringLiteral("dateField"), m_dateField);
   view.insert(QStringLiteral("modifiedAfter"), m_modifiedAfter);
   view.insert(QStringLiteral("tag"), m_tagFilter);
+  view.insert(QStringLiteral("camera"), m_cameraFilter);
+  view.insert(QStringLiteral("lens"), m_lensFilter);
   view.insert(QStringLiteral("sort"), m_sortMode);
   return view;
 }
@@ -479,6 +563,8 @@ void CaptureFilterModel::applyView(const QString& name, const QVariantMap& view,
   m_modifiedAfterMs = QDateTime::fromString(m_modifiedAfter, Qt::ISODate).toMSecsSinceEpoch();
   m_tagFilter = view.value(QStringLiteral("tag")).toString();
   m_tagPaths = QSet<QString>(tagPaths.begin(), tagPaths.end());
+  m_cameraFilter = view.value(QStringLiteral("camera")).toString();
+  m_lensFilter = view.value(QStringLiteral("lens")).toString();
   m_sortMode = qBound(0, view.value(QStringLiteral("sort"), NewestFirst).toInt(),
                       static_cast<int>(NameAscending));
   m_albumFilter.clear();
@@ -495,6 +581,8 @@ void CaptureFilterModel::applyView(const QString& name, const QVariantMap& view,
   emit showHiddenChanged();
   emit dateRangeChanged();
   emit tagFilterChanged();
+  emit cameraFilterChanged();
+  emit lensFilterChanged();
   emit sortModeChanged();
   emit albumFilterChanged();
   emit duplicatesOnlyChanged();
@@ -860,6 +948,12 @@ bool CaptureFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex& sour
     return false;
   }
   if (!m_tagFilter.isEmpty() && !m_tagPaths.contains(record.path)) {
+    return false;
+  }
+  if (!m_cameraFilter.isEmpty() && record.camera != m_cameraFilter) {
+    return false;
+  }
+  if (!m_lensFilter.isEmpty() && record.lens != m_lensFilter) {
     return false;
   }
   if (m_modifiedAfterMs > 0 && record.modified <= m_modifiedAfterMs) {

--- a/src/library/CaptureFilterModel.h
+++ b/src/library/CaptureFilterModel.h
@@ -37,6 +37,11 @@ class CaptureFilterModel final : public QSortFilterProxyModel {
   Q_PROPERTY(QString modifiedAfter READ modifiedAfter NOTIFY dateRangeChanged)
   Q_PROPERTY(QVariantList dateBuckets READ dateBuckets NOTIFY dateBucketsChanged)
   Q_PROPERTY(
+      QString cameraFilter READ cameraFilter WRITE setCameraFilter NOTIFY cameraFilterChanged)
+  Q_PROPERTY(QString lensFilter READ lensFilter WRITE setLensFilter NOTIFY lensFilterChanged)
+  Q_PROPERTY(QVariantList cameras READ cameras NOTIFY camerasChanged)
+  Q_PROPERTY(QVariantList lenses READ lenses NOTIFY camerasChanged)
+  Q_PROPERTY(
       QString smartCollectionFilter READ smartCollectionFilter NOTIFY smartCollectionFilterChanged)
   Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
   Q_PROPERTY(
@@ -97,6 +102,16 @@ public:
   Q_INVOKABLE void clearDateRange();
   [[nodiscard]] QVariantList dateBuckets() const { return m_dateBuckets; }
   Q_INVOKABLE QVariantList dateDays(const QString& monthKey) const;
+
+  // Camera and lens names as the metadata index resolved them. The choice
+  // lists carry {name, count} rows, most used first, and stay empty for a
+  // library of screenshots so the Browse sheet can leave them out.
+  [[nodiscard]] QString cameraFilter() const { return m_cameraFilter; }
+  void setCameraFilter(const QString& camera);
+  [[nodiscard]] QString lensFilter() const { return m_lensFilter; }
+  void setLensFilter(const QString& lens);
+  [[nodiscard]] QVariantList cameras() const { return m_cameras; }
+  [[nodiscard]] QVariantList lenses() const { return m_lenses; }
 
   [[nodiscard]] QString smartCollectionFilter() const { return m_smartCollectionFilter; }
   Q_INVOKABLE QVariantMap currentView() const;
@@ -171,6 +186,9 @@ signals:
   void tagFilterChanged();
   void dateRangeChanged();
   void dateBucketsChanged();
+  void cameraFilterChanged();
+  void lensFilterChanged();
+  void camerasChanged();
   void smartCollectionFilterChanged();
   void showHiddenChanged();
   void duplicatesOnlyChanged();
@@ -187,6 +205,7 @@ private:
   void endFilterUpdate();
   [[nodiscard]] bool rebuildFolderIndex();
   [[nodiscard]] bool rebuildDateIndex();
+  [[nodiscard]] bool rebuildCameraIndex();
   void rebuildDuplicateOrdinals();
   [[nodiscard]] const CaptureRecord& sourceRecord(int sourceRow) const;
   [[nodiscard]] bool recordLessThan(const CaptureRecord& first, const CaptureRecord& second) const;
@@ -211,6 +230,10 @@ private:
   qint64 m_modifiedAfterMs = 0;
   QVariantList m_dateBuckets;
   QHash<QString, QVariantList> m_dateDays;
+  QString m_cameraFilter;
+  QString m_lensFilter;
+  QVariantList m_cameras;
+  QVariantList m_lenses;
   QString m_smartCollectionFilter;
   bool m_favoritesOnly = false;
   bool m_showHidden = false;

--- a/src/library/CaptureModel.cpp
+++ b/src/library/CaptureModel.cpp
@@ -278,6 +278,10 @@ QVariant CaptureModel::data(const QModelIndex& index, int role) const {
     return record.favorite;
   case CaptureRoles::HiddenRole:
     return record.hidden;
+  case CaptureRoles::CameraRole:
+    return record.camera;
+  case CaptureRoles::LensRole:
+    return record.lens;
   default:
     return {};
   }
@@ -300,6 +304,8 @@ QHash<int, QByteArray> CaptureModel::roleNames() const {
       {CaptureRoles::IsDocumentRole, "isDocument"},
       {CaptureRoles::FavoriteRole, "favorite"},
       {CaptureRoles::HiddenRole, "hidden"},
+      {CaptureRoles::CameraRole, "camera"},
+      {CaptureRoles::LensRole, "lens"},
   };
 }
 
@@ -322,42 +328,56 @@ int CaptureModel::rowOf(const QString& path) const {
   return -1;
 }
 
-void CaptureModel::applyCapturedDates(const QList<CapturedDateUpdate>& updates) {
+void CaptureModel::applyMetadata(const QList<MetadataUpdate>& updates) {
   if (updates.isEmpty() || m_records.isEmpty()) {
     return;
   }
 
   int firstChanged = m_records.size();
   int lastChanged = -1;
-  for (const CapturedDateUpdate& update : updates) {
-    if (!update.captured.isValid()) {
-      continue;
-    }
+  bool dateChanged = false;
+  bool cameraChanged = false;
+  for (const MetadataUpdate& update : updates) {
     const int row = rowOf(update.path);
     if (row < 0) {
       continue;
     }
     CaptureRecord& record = m_records[row];
-    if (record.hasProducerTimestamp) {
-      continue;
-    }
     if (record.modified != update.modified || record.bytes != update.bytes ||
         record.device != update.device || record.inode != update.inode) {
       continue;
     }
-    m_capturedDates.insert(record.path, update);
-    if (record.captured == update.captured) {
+    m_metadata.insert(record.path, update);
+    bool changed = false;
+    if (update.captured.isValid() && !record.hasProducerTimestamp &&
+        record.captured != update.captured) {
+      record.captured = update.captured;
+      dateChanged = true;
+      changed = true;
+    }
+    if (record.camera != update.camera || record.lens != update.lens) {
+      record.camera = update.camera;
+      record.lens = update.lens;
+      cameraChanged = true;
+      changed = true;
+    }
+    if (!changed) {
       continue;
     }
-    record.captured = update.captured;
     firstChanged = qMin(firstChanged, row);
-    lastChanged = row;
+    lastChanged = qMax(lastChanged, row);
   }
 
   if (lastChanged >= 0) {
-    emit dataChanged(index(firstChanged), index(lastChanged),
-                     {CaptureRoles::CapturedRole, CaptureRoles::DayKeyRole,
-                      CaptureRoles::DayLabelRole, CaptureRoles::TimeLabelRole});
+    QList<int> roles;
+    if (dateChanged) {
+      roles.append({CaptureRoles::CapturedRole, CaptureRoles::DayKeyRole,
+                    CaptureRoles::DayLabelRole, CaptureRoles::TimeLabelRole});
+    }
+    if (cameraChanged) {
+      roles.append({CaptureRoles::CameraRole, CaptureRoles::LensRole});
+    }
+    emit dataChanged(index(firstChanged), index(lastChanged), roles);
   }
 }
 
@@ -450,28 +470,32 @@ void CaptureModel::adoptResults(ScanResult result) {
     }
   }
 
-  // Keep already-resolved metadata dates through ordinary watcher rescans.
-  // Without this, every new screenshot would briefly put copied photos back
-  // on their mtime dates until the date cache was applied again.
-  QSet<QString> liveDatePaths;
-  liveDatePaths.reserve(scanned.size());
+  // Keep already-resolved metadata through ordinary watcher rescans. Without
+  // this, every new screenshot would briefly put copied photos back on their
+  // mtime dates, and drop their cameras, until the cache was applied again.
+  QSet<QString> livePaths;
+  livePaths.reserve(scanned.size());
   for (CaptureRecord& record : scanned) {
-    const auto known = m_capturedDates.constFind(record.path);
-    if (known == m_capturedDates.cend()) {
+    const auto known = m_metadata.constFind(record.path);
+    if (known == m_metadata.cend()) {
       continue;
     }
-    if (!record.hasProducerTimestamp && known->modified == record.modified &&
-        known->bytes == record.bytes && known->device == record.device &&
-        known->inode == record.inode && known->captured.isValid()) {
-      record.captured = known->captured;
-      liveDatePaths.insert(record.path);
+    if (known->modified != record.modified || known->bytes != record.bytes ||
+        known->device != record.device || known->inode != record.inode) {
+      continue;
     }
+    if (!record.hasProducerTimestamp && known->captured.isValid()) {
+      record.captured = known->captured;
+    }
+    record.camera = known->camera;
+    record.lens = known->lens;
+    livePaths.insert(record.path);
   }
-  for (auto it = m_capturedDates.begin(); it != m_capturedDates.end();) {
-    if (liveDatePaths.contains(it.key())) {
+  for (auto it = m_metadata.begin(); it != m_metadata.end();) {
+    if (livePaths.contains(it.key())) {
       ++it;
     } else {
-      it = m_capturedDates.erase(it);
+      it = m_metadata.erase(it);
     }
   }
 

--- a/src/library/CaptureModel.h
+++ b/src/library/CaptureModel.h
@@ -54,18 +54,21 @@ public:
   // for a QVariant per role per comparison across the whole library.
   [[nodiscard]] const CaptureRecord& recordAt(int row) const { return m_records.at(row); }
 
-  struct CapturedDateUpdate {
+  struct MetadataUpdate {
     QString path;
     qint64 modified = 0;
     qint64 bytes = 0;
     QDateTime captured;
     quint64 device = 0;
     quint64 inode = 0;
+    QString camera;
+    QString lens;
   };
 
-  // Replaces mtime fallbacks with dates read from embedded media metadata.
-  // File identity is checked again here because extraction is asynchronous.
-  void applyCapturedDates(const QList<CapturedDateUpdate>& updates);
+  // Replaces mtime fallbacks with dates read from embedded media metadata and
+  // records the camera and lens. File identity is checked again here because
+  // extraction is asynchronous.
+  void applyMetadata(const QList<MetadataUpdate>& updates);
 
   // A directory handed to omaroll on the command line or by "Open with",
   // scanned alongside the usual roots for this session only.
@@ -137,7 +140,7 @@ private:
   QList<CaptureRecord> m_records;
   QHash<QString, int> m_rowsByPath;
   bool m_rowIndexValid = true;
-  QHash<QString, CapturedDateUpdate> m_capturedDates;
+  QHash<QString, MetadataUpdate> m_metadata;
   QFileSystemWatcher m_watcher;
   QFutureWatcher<ScanResult> m_scanWatcher;
   // Set on teardown so a scan in flight stops walking instead of finishing a

--- a/src/library/CaptureRecord.h
+++ b/src/library/CaptureRecord.h
@@ -26,6 +26,10 @@ struct CaptureRecord {
   // their mtime fallback replaced later by embedded metadata without making
   // capture discovery wait for ImageMagick or ffprobe.
   bool hasProducerTimestamp = false;
+  // Filled in later from embedded metadata, the same way as the date. Empty
+  // for screenshots, recordings and anything without EXIF.
+  QString camera;
+  QString lens;
   qint64 bytes = 0;
   // mtime in milliseconds. Part of the thumbnail identity, so a file rewritten
   // in place (a recording finalised by omarchy-capture-screenrecording) gets a

--- a/src/library/CaptureRoles.h
+++ b/src/library/CaptureRoles.h
@@ -22,6 +22,8 @@ enum Role {
   IsDocumentRole,
   FavoriteRole,
   HiddenRole,
+  CameraRole,
+  LensRole,
   // Added by CaptureFilterModel while a search result needs OCR context.
   OcrSnippetRole,
 };

--- a/src/library/MediaMetadataIndex.cpp
+++ b/src/library/MediaMetadataIndex.cpp
@@ -1,4 +1,4 @@
-#include "library/MediaDateIndex.h"
+#include "library/MediaMetadataIndex.h"
 
 #include <QDataStream>
 #include <QDir>
@@ -17,7 +17,7 @@
 namespace {
 
 constexpr quint32 kCacheMagic = 0x4f4d4431; // OMD1
-constexpr quint16 kCacheVersion = 2;
+constexpr quint16 kCacheVersion = 3;
 constexpr qint64 kMaximumCacheBytes = 16LL * 1024 * 1024;
 constexpr quint32 kMaximumCacheEntries = 100'000;
 constexpr int kImageBatchSize = 32;
@@ -75,13 +75,23 @@ QDateTime dateFromTags(const QJsonObject& tags) {
   return {};
 }
 
+QString tagValue(const QJsonObject& tags, const QStringList& keys) {
+  for (const QString& key : keys) {
+    const QString value = cleanValue(tags.value(key).toString());
+    if (!value.isEmpty()) {
+      return value;
+    }
+  }
+  return {};
+}
+
 QString identityKey(qint64 modified, qint64 bytes, quint64 device, quint64 inode) {
   return QStringLiteral("%1:%2:%3:%4").arg(modified).arg(bytes).arg(device).arg(inode);
 }
 
 } // namespace
 
-MediaDateIndex::MediaDateIndex(CaptureModel* model, QObject* parent)
+MediaMetadataIndex::MediaMetadataIndex(CaptureModel* model, QObject* parent)
     : QObject(parent), m_model(model),
       m_imageProgram(QStandardPaths::findExecutable(QStringLiteral("magick"))),
       m_videoProgram(QStandardPaths::findExecutable(QStringLiteral("ffprobe"))) {
@@ -100,12 +110,12 @@ MediaDateIndex::MediaDateIndex(CaptureModel* model, QObject* parent)
 
   m_syncTimer.setSingleShot(true);
   m_syncTimer.setInterval(100);
-  connect(&m_syncTimer, &QTimer::timeout, this, &MediaDateIndex::sync);
+  connect(&m_syncTimer, &QTimer::timeout, this, &MediaMetadataIndex::sync);
 
   m_saveTimer.setSingleShot(true);
   // Batch many quick metadata reads into one small atomic cache write.
   m_saveTimer.setInterval(5000);
-  connect(&m_saveTimer, &QTimer::timeout, this, &MediaDateIndex::saveCache);
+  connect(&m_saveTimer, &QTimer::timeout, this, &MediaMetadataIndex::saveCache);
 
   if (m_model) {
     connect(m_model, &CaptureModel::countChanged, &m_syncTimer, qOverload<>(&QTimer::start));
@@ -115,7 +125,7 @@ MediaDateIndex::MediaDateIndex(CaptureModel* model, QObject* parent)
   }
 }
 
-MediaDateIndex::~MediaDateIndex() {
+MediaMetadataIndex::~MediaMetadataIndex() {
   disconnect(&m_process, nullptr, this, nullptr);
   if (m_process.state() != QProcess::NotRunning) {
     m_process.kill();
@@ -126,11 +136,11 @@ MediaDateIndex::~MediaDateIndex() {
   }
 }
 
-QString MediaDateIndex::cachePath() {
-  return cacheHome() + QStringLiteral("/omaroll/media-dates.index");
+QString MediaMetadataIndex::cachePath() {
+  return cacheHome() + QStringLiteral("/omaroll/media-metadata.index");
 }
 
-QDateTime MediaDateIndex::parseImageDate(const QByteArray& output) {
+QDateTime MediaMetadataIndex::parseImageDate(const QByteArray& output) {
   const QStringList fields = QString::fromUtf8(output).split(QLatin1Char('\n'), Qt::KeepEmptyParts);
   for (int index = 0; index < 2; ++index) {
     const QDateTime parsed = exifDate(fields.value(index));
@@ -141,9 +151,30 @@ QDateTime MediaDateIndex::parseImageDate(const QByteArray& output) {
   return {};
 }
 
-QHash<int, QDateTime> MediaDateIndex::parseImageBatch(const QByteArray& output,
-                                                      QSet<int>* completed) {
-  QHash<int, QDateTime> dates;
+QString MediaMetadataIndex::cameraName(const QString& make, const QString& model) {
+  const QString cleanMake = cleanValue(make).simplified();
+  const QString cleanModel = cleanValue(model).simplified();
+  if (cleanModel.isEmpty()) {
+    return cleanMake;
+  }
+  if (cleanMake.isEmpty() || cleanModel.startsWith(cleanMake, Qt::CaseInsensitive)) {
+    return cleanModel;
+  }
+  return cleanMake + QLatin1Char(' ') + cleanModel;
+}
+
+MediaMetadataIndex::Details MediaMetadataIndex::parseImageDetails(const QByteArray& output) {
+  const QStringList fields = QString::fromUtf8(output).split(QLatin1Char('\n'), Qt::KeepEmptyParts);
+  Details details;
+  details.captured = parseImageDate(output);
+  details.camera = cameraName(fields.value(2), fields.value(3));
+  details.lens = cleanValue(fields.value(4)).simplified();
+  return details;
+}
+
+QHash<int, MediaMetadataIndex::Details> MediaMetadataIndex::parseImageBatch(
+    const QByteArray& output, QSet<int>* completed) {
+  QHash<int, Details> results;
   const QStringList lines = QString::fromUtf8(output).split(QLatin1Char('\n'), Qt::KeepEmptyParts);
   const QString prefix = QString::fromLatin1(kImageRecordPrefix);
   for (int line = 0; line < lines.size(); ++line) {
@@ -156,14 +187,18 @@ QHash<int, QDateTime> MediaDateIndex::parseImageBatch(const QByteArray& output,
       continue;
     }
     completed->insert(index);
-    const QString fields =
-        lines.value(line + 1) + QLatin1Char('\n') + lines.value(line + 2) + QLatin1Char('\n');
-    dates.insert(index, parseImageDate(fields.toUtf8()));
+    // Everything up to the next record marker belongs to this file. Fields
+    // stay positional, so a short record simply has empty trailing fields.
+    QStringList fields;
+    for (int next = line + 1; next < lines.size() && !lines.at(next).startsWith(prefix); ++next) {
+      fields.append(lines.at(next));
+    }
+    results.insert(index, parseImageDetails(fields.join(QLatin1Char('\n')).toUtf8()));
   }
-  return dates;
+  return results;
 }
 
-QDateTime MediaDateIndex::parseVideoDate(const QByteArray& output) {
+QDateTime MediaMetadataIndex::parseVideoDate(const QByteArray& output) {
   QJsonParseError error;
   const QJsonDocument document = QJsonDocument::fromJson(output, &error);
   if (error.error != QJsonParseError::NoError || !document.isObject()) {
@@ -185,12 +220,34 @@ QDateTime MediaDateIndex::parseVideoDate(const QByteArray& output) {
   return {};
 }
 
-void MediaDateIndex::sync() {
+MediaMetadataIndex::Details MediaMetadataIndex::parseVideoDetails(const QByteArray& output) {
+  Details details;
+  details.captured = parseVideoDate(output);
+  QJsonParseError error;
+  const QJsonDocument document = QJsonDocument::fromJson(output, &error);
+  if (error.error != QJsonParseError::NoError || !document.isObject()) {
+    return details;
+  }
+  const QJsonObject tags =
+      document.object().value(QStringLiteral("format")).toObject().value(QStringLiteral("tags")).toObject();
+  details.camera = cameraName(
+      tagValue(tags, {QStringLiteral("com.apple.quicktime.make"), QStringLiteral("make")}),
+      tagValue(tags, {QStringLiteral("com.apple.quicktime.model"), QStringLiteral("model")}));
+  return details;
+}
+
+CaptureModel::MetadataUpdate MediaMetadataIndex::updateFor(const Candidate& candidate,
+                                                           const Details& details) {
+  return {candidate.path,   candidate.modified, candidate.bytes, details.captured,
+          candidate.device, candidate.inode,    details.camera,  details.lens};
+}
+
+void MediaMetadataIndex::sync() {
   if (!m_model) {
     return;
   }
 
-  QList<CaptureModel::CapturedDateUpdate> cachedDates;
+  QList<CaptureModel::MetadataUpdate> cachedUpdates;
   m_queue.clear();
   // Group images so one ImageMagick process can inspect a bounded batch.
   // Each group remains newest-first in the model's scan order.
@@ -208,9 +265,8 @@ void MediaDateIndex::sync() {
       if (known != m_entries.cend() && known->modified == record.modified &&
           known->bytes == record.bytes && known->device == record.device &&
           known->inode == record.inode) {
-        if (known->captured.isValid()) {
-          cachedDates.append({record.path, record.modified, record.bytes, known->captured,
-                              record.device, record.inode});
+        if (known->details != Details {}) {
+          cachedUpdates.append(updateFor(candidate, known->details));
         }
         continue;
       }
@@ -230,12 +286,12 @@ void MediaDateIndex::sync() {
     }
   }
 
-  if (m_indexing || !m_current.isEmpty() || !m_pendingDates.isEmpty()) {
-    for (const CaptureModel::CapturedDateUpdate& update : std::as_const(cachedDates)) {
-      m_pendingDates.insert(update.path, update);
+  if (m_indexing || !m_current.isEmpty() || !m_pendingUpdates.isEmpty()) {
+    for (const CaptureModel::MetadataUpdate& update : std::as_const(cachedUpdates)) {
+      m_pendingUpdates.insert(update.path, update);
     }
   } else {
-    m_model->applyCapturedDates(cachedDates);
+    m_model->applyMetadata(cachedUpdates);
   }
   resetProgress(m_queue.size() + m_current.size());
   setIndexing(!m_current.isEmpty() || !m_queue.isEmpty());
@@ -245,14 +301,14 @@ void MediaDateIndex::sync() {
   processNext();
 }
 
-void MediaDateIndex::processNext() {
+void MediaMetadataIndex::processNext() {
   if (m_process.state() != QProcess::NotRunning || !m_current.isEmpty()) {
     return;
   }
   if (m_queue.isEmpty()) {
-    if (!m_pendingDates.isEmpty()) {
-      m_model->applyCapturedDates(m_pendingDates.values());
-      m_pendingDates.clear();
+    if (!m_pendingUpdates.isEmpty()) {
+      m_model->applyMetadata(m_pendingUpdates.values());
+      m_pendingUpdates.clear();
     }
     setIndexing(false);
     return;
@@ -261,7 +317,7 @@ void MediaDateIndex::processNext() {
   const Candidate first = m_queue.takeFirst();
   if (!stillCurrent(first)) {
     advanceProgress();
-    QTimer::singleShot(0, this, &MediaDateIndex::processNext);
+    QTimer::singleShot(0, this, &MediaMetadataIndex::processNext);
     return;
   }
 
@@ -282,7 +338,8 @@ void MediaDateIndex::processNext() {
   if (first.video) {
     m_process.setArguments(
         {QStringLiteral("-v"), QStringLiteral("error"), QStringLiteral("-show_entries"),
-         QStringLiteral("format_tags=creation_time,com.apple.quicktime.creationdate:"
+         QStringLiteral("format_tags=creation_time,com.apple.quicktime.creationdate,"
+                        "com.apple.quicktime.make,com.apple.quicktime.model,make,model:"
                         "stream_tags=creation_time,com.apple.quicktime.creationdate"),
          QStringLiteral("-of"), QStringLiteral("json"), first.path});
     m_timeout.setInterval(kVideoProbeTimeoutMs);
@@ -292,7 +349,8 @@ void MediaDateIndex::processNext() {
     for (int index = 0; index < m_current.size(); ++index) {
       arguments.append({QStringLiteral("-format"),
                         QStringLiteral("%1%2\\n%[EXIF:DateTimeOriginal]\\n"
-                                       "%[EXIF:DateTimeDigitized]\\n")
+                                       "%[EXIF:DateTimeDigitized]\\n%[EXIF:Make]\\n"
+                                       "%[EXIF:Model]\\n%[EXIF:LensModel]\\n")
                             .arg(QString::fromLatin1(kImageRecordPrefix))
                             .arg(index),
                         m_current.at(index).path});
@@ -304,7 +362,7 @@ void MediaDateIndex::processNext() {
   m_timeout.start();
 }
 
-void MediaDateIndex::finishCurrent(bool successful) {
+void MediaMetadataIndex::finishCurrent(bool successful) {
   if (m_current.isEmpty()) {
     return;
   }
@@ -315,7 +373,7 @@ void MediaDateIndex::finishCurrent(bool successful) {
   if (batch.first().video) {
     const Candidate& candidate = batch.first();
     if (successful && stillCurrent(candidate)) {
-      adopt(candidate, parseVideoDate(output));
+      adopt(candidate, parseVideoDetails(output));
     } else if (stillCurrent(candidate)) {
       m_failed.insert(candidate.path, identityKey(candidate.modified, candidate.bytes,
                                                   candidate.device, candidate.inode));
@@ -323,11 +381,11 @@ void MediaDateIndex::finishCurrent(bool successful) {
     advanceProgress();
   } else {
     QSet<int> completed;
-    const QHash<int, QDateTime> dates = parseImageBatch(output, &completed);
+    const QHash<int, Details> results = parseImageBatch(output, &completed);
     for (int index = 0; index < batch.size(); ++index) {
       const Candidate& candidate = batch.at(index);
       if (completed.contains(index) && stillCurrent(candidate)) {
-        adopt(candidate, dates.value(index));
+        adopt(candidate, results.value(index));
       } else if (stillCurrent(candidate)) {
         m_failed.insert(candidate.path, identityKey(candidate.modified, candidate.bytes,
                                                     candidate.device, candidate.inode));
@@ -335,10 +393,10 @@ void MediaDateIndex::finishCurrent(bool successful) {
     }
     advanceProgress(static_cast<int>(batch.size()));
   }
-  QTimer::singleShot(0, this, &MediaDateIndex::processNext);
+  QTimer::singleShot(0, this, &MediaMetadataIndex::processNext);
 }
 
-bool MediaDateIndex::isCurrent(const Candidate& candidate) const {
+bool MediaMetadataIndex::isCurrent(const Candidate& candidate) const {
   return std::any_of(m_current.cbegin(), m_current.cend(), [&candidate](const Candidate& current) {
     return current.path == candidate.path && current.modified == candidate.modified &&
            current.bytes == candidate.bytes && current.device == candidate.device &&
@@ -346,7 +404,7 @@ bool MediaDateIndex::isCurrent(const Candidate& candidate) const {
   });
 }
 
-bool MediaDateIndex::stillCurrent(const Candidate& candidate) const {
+bool MediaMetadataIndex::stillCurrent(const Candidate& candidate) const {
   if (!m_model) {
     return false;
   }
@@ -360,19 +418,18 @@ bool MediaDateIndex::stillCurrent(const Candidate& candidate) const {
          record.device == candidate.device && record.inode == candidate.inode;
 }
 
-void MediaDateIndex::adopt(const Candidate& candidate, const QDateTime& captured) {
-  m_entries.insert(candidate.path, {candidate.modified, candidate.bytes, captured, candidate.device,
+void MediaMetadataIndex::adopt(const Candidate& candidate, const Details& details) {
+  m_entries.insert(candidate.path, {candidate.modified, candidate.bytes, details, candidate.device,
                                     candidate.inode});
   m_failed.remove(candidate.path);
   m_cacheDirty = true;
   scheduleSave();
-  if (captured.isValid()) {
-    m_pendingDates.insert(candidate.path, {candidate.path, candidate.modified, candidate.bytes,
-                                           captured, candidate.device, candidate.inode});
+  if (details != Details {}) {
+    m_pendingUpdates.insert(candidate.path, updateFor(candidate, details));
   }
 }
 
-void MediaDateIndex::setIndexing(bool value) {
+void MediaMetadataIndex::setIndexing(bool value) {
   if (m_indexing == value) {
     return;
   }
@@ -380,7 +437,7 @@ void MediaDateIndex::setIndexing(bool value) {
   emit indexingChanged();
 }
 
-void MediaDateIndex::resetProgress(int total) {
+void MediaMetadataIndex::resetProgress(int total) {
   total = qMax(0, total);
   if (m_completed == 0 && m_total == total) {
     return;
@@ -390,7 +447,7 @@ void MediaDateIndex::resetProgress(int total) {
   emit progressChanged();
 }
 
-void MediaDateIndex::advanceProgress(int amount) {
+void MediaMetadataIndex::advanceProgress(int amount) {
   if (m_completed >= m_total) {
     return;
   }
@@ -398,7 +455,7 @@ void MediaDateIndex::advanceProgress(int amount) {
   emit progressChanged();
 }
 
-void MediaDateIndex::loadCache() {
+void MediaMetadataIndex::loadCache() {
   QFile file(cachePath());
   if (!file.open(QIODevice::ReadOnly) || file.size() > kMaximumCacheBytes) {
     return;
@@ -419,8 +476,8 @@ void MediaDateIndex::loadCache() {
   for (quint32 index = 0; index < count; ++index) {
     QString path;
     Entry entry;
-    stream >> path >> entry.modified >> entry.bytes >> entry.captured >> entry.device >>
-        entry.inode;
+    stream >> path >> entry.modified >> entry.bytes >> entry.details.captured >>
+        entry.details.camera >> entry.details.lens >> entry.device >> entry.inode;
     if (stream.status() != QDataStream::Ok || path.isEmpty()) {
       return;
     }
@@ -431,13 +488,13 @@ void MediaDateIndex::loadCache() {
   }
 }
 
-void MediaDateIndex::scheduleSave() {
+void MediaMetadataIndex::scheduleSave() {
   if (!m_saveTimer.isActive()) {
     m_saveTimer.start();
   }
 }
 
-void MediaDateIndex::saveCache() {
+void MediaMetadataIndex::saveCache() {
   if (!m_cacheDirty) {
     return;
   }
@@ -467,8 +524,11 @@ void MediaDateIndex::saveCache() {
   qint64 estimatedBytes = 64;
   for (const QString& key : std::as_const(ordered)) {
     // QDataStream stores QString as UTF-16 plus fixed-size identity fields.
-    // The extra margin covers QDateTime's zone representation and framing.
-    const qint64 entryBytes = 256 + qint64(key.size()) * 2;
+    // The extra margin covers QDateTime's zone representation, the camera
+    // and lens names, and framing.
+    const Entry& sized = m_entries[key];
+    const qint64 entryBytes =
+        320 + qint64(key.size() + sized.details.camera.size() + sized.details.lens.size()) * 2;
     if (retained.size() >= static_cast<int>(kMaximumCacheEntries) ||
         estimatedBytes + entryBytes > kMaximumCacheBytes) {
       continue;
@@ -493,7 +553,8 @@ void MediaDateIndex::saveCache() {
   stream << kCacheMagic << kCacheVersion << static_cast<quint32>(retained.size());
   for (const QString& key : std::as_const(retained)) {
     const Entry entry = m_entries.value(key);
-    stream << key << entry.modified << entry.bytes << entry.captured << entry.device << entry.inode;
+    stream << key << entry.modified << entry.bytes << entry.details.captured
+           << entry.details.camera << entry.details.lens << entry.device << entry.inode;
   }
   if (stream.status() == QDataStream::Ok && file.size() <= kMaximumCacheBytes && file.commit()) {
     QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::WriteOwner);

--- a/src/library/MediaMetadataIndex.h
+++ b/src/library/MediaMetadataIndex.h
@@ -9,23 +9,34 @@
 #include <QSet>
 #include <QTimer>
 
-// Reads the original capture date embedded in general photos and videos.
+// Reads embedded metadata from general photos and videos: the original
+// capture date, and the camera and lens that took them.
 //
 // Discovery itself stays a fast filesystem walk. Once a scan lands, this
 // class checks small image batches with ImageMagick and videos one at a time
 // with ffprobe, then replaces only mtime fallbacks. Omarchy's timestamped
-// capture names always remain authoritative. Results, including "no embedded
-// date", are cached by path and filesystem identity so an unchanged library
-// is not probed every launch.
-class MediaDateIndex final : public QObject {
+// capture names always remain authoritative. Results, including "nothing
+// embedded", are cached by path and filesystem identity so an unchanged
+// library is not probed every launch.
+class MediaMetadataIndex final : public QObject {
   Q_OBJECT
   Q_PROPERTY(bool indexing READ indexing NOTIFY indexingChanged)
   Q_PROPERTY(int completed READ completed NOTIFY progressChanged)
   Q_PROPERTY(int total READ total NOTIFY progressChanged)
 
 public:
-  explicit MediaDateIndex(CaptureModel* model, QObject* parent = nullptr);
-  ~MediaDateIndex() override;
+  // What one probe found. Empty strings and an invalid date mean the file
+  // carries nothing, which is still worth caching.
+  struct Details {
+    QDateTime captured;
+    QString camera;
+    QString lens;
+
+    bool operator==(const Details& other) const = default;
+  };
+
+  explicit MediaMetadataIndex(CaptureModel* model, QObject* parent = nullptr);
+  ~MediaMetadataIndex() override;
 
   [[nodiscard]] bool indexing() const { return m_indexing; }
   [[nodiscard]] int completed() const { return m_completed; }
@@ -33,7 +44,11 @@ public:
 
   [[nodiscard]] static QString cachePath();
   [[nodiscard]] static QDateTime parseImageDate(const QByteArray& output);
+  [[nodiscard]] static Details parseImageDetails(const QByteArray& output);
   [[nodiscard]] static QDateTime parseVideoDate(const QByteArray& output);
+  [[nodiscard]] static Details parseVideoDetails(const QByteArray& output);
+  // "Apple iPhone 12", or just the model when the maker already leads it.
+  [[nodiscard]] static QString cameraName(const QString& make, const QString& model);
 
 signals:
   void indexingChanged();
@@ -52,7 +67,7 @@ private:
   struct Entry {
     qint64 modified = 0;
     qint64 bytes = 0;
-    QDateTime captured;
+    Details details;
     quint64 device = 0;
     quint64 inode = 0;
   };
@@ -62,9 +77,11 @@ private:
   void finishCurrent(bool successful);
   [[nodiscard]] bool isCurrent(const Candidate& candidate) const;
   [[nodiscard]] bool stillCurrent(const Candidate& candidate) const;
-  [[nodiscard]] static QHash<int, QDateTime> parseImageBatch(
-      const QByteArray& output, QSet<int>* completed);
-  void adopt(const Candidate& candidate, const QDateTime& captured);
+  [[nodiscard]] static QHash<int, Details> parseImageBatch(const QByteArray& output,
+                                                           QSet<int>* completed);
+  void adopt(const Candidate& candidate, const Details& details);
+  [[nodiscard]] static CaptureModel::MetadataUpdate updateFor(const Candidate& candidate,
+                                                              const Details& details);
   void setIndexing(bool value);
   void resetProgress(int total);
   void advanceProgress(int amount = 1);
@@ -77,7 +94,7 @@ private:
   QString m_videoProgram;
   QHash<QString, Entry> m_entries;
   QList<Candidate> m_queue;
-  QHash<QString, CaptureModel::CapturedDateUpdate> m_pendingDates;
+  QHash<QString, CaptureModel::MetadataUpdate> m_pendingUpdates;
   QHash<QString, QString> m_failed;
   QList<Candidate> m_current;
   QProcess m_process;

--- a/tests/tst_omaroll.cpp
+++ b/tests/tst_omaroll.cpp
@@ -12,7 +12,7 @@
 #include "library/CaptureModel.h"
 #include "library/CaptureRoles.h"
 #include "library/DuplicateIndex.h"
-#include "library/MediaDateIndex.h"
+#include "library/MediaMetadataIndex.h"
 #include "library/MediaInspector.h"
 #include "library/SimilarityIndex.h"
 #include "matte/HueExtractor.h"
@@ -1178,6 +1178,39 @@ private slots:
     QTRY_VERIFY_WITH_TIMEOUT(!proxy.dateBuckets().isEmpty(), 1000);
     QCOMPARE(proxy.dateDays(QStringLiteral("2026-08")).size(), 5);
 
+    // Camera and lens filters come from the metadata index. The choice lists
+    // count the library, not the current view, and the filter survives a
+    // saved view round trip.
+    QVERIFY(proxy.cameras().isEmpty());
+    const CaptureRecord& beachRecord = model.recordAt(model.rowOf(beach));
+    model.applyMetadata({{beach, beachRecord.modified, beachRecord.bytes, {}, beachRecord.device,
+                          beachRecord.inode, QStringLiteral("Sony ILCE-7M3"),
+                          QStringLiteral("FE 24-70mm F2.8 GM")}});
+    QTRY_COMPARE_WITH_TIMEOUT(proxy.cameras().size(), 1, 1000);
+    QCOMPARE(proxy.cameras().first().toMap().value(QStringLiteral("name")).toString(),
+             QStringLiteral("Sony ILCE-7M3"));
+    QCOMPARE(proxy.cameras().first().toMap().value(QStringLiteral("count")).toInt(), 1);
+    QCOMPARE(proxy.lenses().size(), 1);
+    proxy.setCameraFilter(QStringLiteral("Sony ILCE-7M3"));
+    QCOMPARE(proxy.count(), 1);
+    QCOMPARE(proxy.pathAt(0), beach);
+    proxy.setLensFilter(QStringLiteral("Some other lens"));
+    QCOMPARE(proxy.count(), 0);
+    proxy.setLensFilter(QStringLiteral("FE 24-70mm F2.8 GM"));
+    QCOMPARE(proxy.count(), 1);
+    const QVariantMap cameraView = proxy.currentView();
+    QCOMPARE(cameraView.value(QStringLiteral("camera")).toString(), QStringLiteral("Sony ILCE-7M3"));
+    proxy.setCameraFilter({});
+    proxy.setLensFilter({});
+    QCOMPARE(proxy.count(), 5);
+    proxy.applyView(QStringLiteral("Sony shots"), cameraView);
+    QCOMPARE(proxy.cameraFilter(), QStringLiteral("Sony ILCE-7M3"));
+    QCOMPARE(proxy.count(), 1);
+    proxy.clearSmartCollection();
+    proxy.setCameraFilter({});
+    proxy.setLensFilter({});
+    QCOMPARE(proxy.count(), 5);
+
     const QString forest = dir.filePath(QStringLiteral("album/forest.png"));
     proxy.setTagFilter(QStringLiteral("Review"), {beach, forest});
     QCOMPARE(proxy.count(), 2);
@@ -1998,19 +2031,52 @@ private slots:
   }
 
   void embeddedMediaDatesParseWithoutChangingWallClockPhotoTime() {
-    QCOMPARE(MediaDateIndex::parseImageDate("2020:05:06 07:08:09\n2019:01:02 03:04:05\n"),
+    QCOMPARE(MediaMetadataIndex::parseImageDate("2020:05:06 07:08:09\n2019:01:02 03:04:05\n"),
              QDateTime(QDate(2020, 5, 6), QTime(7, 8, 9)));
-    QCOMPARE(MediaDateIndex::parseImageDate("\n2019:01:02 03:04:05\n"),
+    QCOMPARE(MediaMetadataIndex::parseImageDate("\n2019:01:02 03:04:05\n"),
              QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5)));
-    QVERIFY(!MediaDateIndex::parseImageDate("undefined\n\n").isValid());
+    QVERIFY(!MediaMetadataIndex::parseImageDate("undefined\n\n").isValid());
 
     const QByteArray video = R"({
       "streams": [{"tags":{"creation_time":"2018-04-03T02:01:00"}}],
       "format": {"tags":{"com.apple.quicktime.creationdate":"2021-08-09T10:11:12"}}
     })";
-    QCOMPARE(MediaDateIndex::parseVideoDate(video),
+    QCOMPARE(MediaMetadataIndex::parseVideoDate(video),
              QDateTime(QDate(2021, 8, 9), QTime(10, 11, 12)));
-    QVERIFY(!MediaDateIndex::parseVideoDate("not json").isValid());
+    QVERIFY(!MediaMetadataIndex::parseVideoDate("not json").isValid());
+  }
+
+  void embeddedCameraNamesParseAndNormalize() {
+    QCOMPARE(MediaMetadataIndex::cameraName(QStringLiteral("Apple"), QStringLiteral("iPhone 12")),
+             QStringLiteral("Apple iPhone 12"));
+    // Canon and Nikon repeat the maker in the model; do not print it twice.
+    QCOMPARE(MediaMetadataIndex::cameraName(QStringLiteral("Canon"),
+                                            QStringLiteral("Canon EOS R6")),
+             QStringLiteral("Canon EOS R6"));
+    QCOMPARE(MediaMetadataIndex::cameraName(QStringLiteral("SONY  "), QString()),
+             QStringLiteral("SONY"));
+    QCOMPARE(MediaMetadataIndex::cameraName(QStringLiteral("undefined"), QStringLiteral("X-T5")),
+             QStringLiteral("X-T5"));
+    QVERIFY(MediaMetadataIndex::cameraName({}, {}).isEmpty());
+
+    const MediaMetadataIndex::Details image = MediaMetadataIndex::parseImageDetails(
+        "2020:05:06 07:08:09\n\nFUJIFILM\nX-T5\nXF16-55mmF2.8 R LM WR\n");
+    QCOMPARE(image.captured, QDateTime(QDate(2020, 5, 6), QTime(7, 8, 9)));
+    QCOMPARE(image.camera, QStringLiteral("FUJIFILM X-T5"));
+    QCOMPARE(image.lens, QStringLiteral("XF16-55mmF2.8 R LM WR"));
+    // A record cut short by the producer still parses positionally.
+    const MediaMetadataIndex::Details bare = MediaMetadataIndex::parseImageDetails("\n\n");
+    QVERIFY(!bare.captured.isValid());
+    QVERIFY(bare.camera.isEmpty());
+    QVERIFY(bare.lens.isEmpty());
+    QCOMPARE(bare, MediaMetadataIndex::Details {});
+
+    const MediaMetadataIndex::Details video = MediaMetadataIndex::parseVideoDetails(
+        "{\"format\":{\"tags\":{\"creation_time\":\"2021-08-09T10:11:12\","
+        "\"com.apple.quicktime.make\":\"Apple\",\"com.apple.quicktime.model\":\"iPhone 12\"}}}");
+    QCOMPARE(video.captured, QDateTime(QDate(2021, 8, 9), QTime(10, 11, 12)));
+    QCOMPARE(video.camera, QStringLiteral("Apple iPhone 12"));
+    QVERIFY(MediaMetadataIndex::parseVideoDetails("not json").camera.isEmpty());
   }
 
   void generalMediaDatesAreEnrichedOnceAndProducerDatesAlwaysWin() {
@@ -2046,7 +2112,8 @@ private slots:
                  "    printf '\\036OMAROLL_DATE:%s\\n' \"$index\"\n"
                  "    case \"$3\" in\n"
                  "      *undated*) printf '\\n\\n' ;;\n"
-                 "      *) printf '2020:05:06 07:08:09\\n\\n' ;;\n"
+                 "      *) printf '2020:05:06 07:08:09\\n\\nApple\\niPhone 12\\n"
+                 "iPhone 12 back camera\\n' ;;\n"
                  "    esac\n"
                  "    index=$((index + 1))\n"
                  "    shift 3\n"
@@ -2063,7 +2130,8 @@ private slots:
     ffprobe.write("#!/bin/sh\n"
                   "printf '%s\\n' "
                   "'{\"format\":{\"tags\":{\"creation_time\":\"2021-08-09T10:"
-                  "11:12\"}}}'\n"
+                  "11:12\",\"com.apple.quicktime.make\":\"Apple\","
+                  "\"com.apple.quicktime.model\":\"iPhone 12\"}}}'\n"
                   "printf 'video\\n' >> \"$OMAROLL_DATE_TEST_LOG\"\n");
     ffprobe.close();
     QVERIFY(ffprobe.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner |
@@ -2089,7 +2157,7 @@ private slots:
     clip.write("test video");
     clip.close();
 
-    QFile::remove(MediaDateIndex::cachePath());
+    QFile::remove(MediaMetadataIndex::cachePath());
     AppSettings settings;
     settings.setScanDownloads(false);
     CaptureModel model(&settings);
@@ -2104,7 +2172,7 @@ private slots:
     const QDateTime undatedFallback = model.recordAt(model.rowOf(undated)).captured;
 
     {
-      MediaDateIndex dates(&model);
+      MediaMetadataIndex dates(&model);
       QTRY_COMPARE_WITH_TIMEOUT(dates.total(), 3, 2000);
       QTRY_VERIFY_WITH_TIMEOUT(!dates.indexing(), 3000);
       QCOMPARE(dates.completed(), 3);
@@ -2115,14 +2183,21 @@ private slots:
       QCOMPARE(model.recordAt(model.rowOf(capture)).captured,
                QDateTime(QDate(2026, 8, 31), QTime(10, 0)));
       QCOMPARE(model.recordAt(model.rowOf(undated)).captured, undatedFallback);
+      // The same probe fills in the camera, so a photo library can be browsed
+      // by camera without a second pass over the files.
+      QCOMPARE(model.recordAt(model.rowOf(photo)).camera, QStringLiteral("Apple iPhone 12"));
+      QCOMPARE(model.recordAt(model.rowOf(photo)).lens, QStringLiteral("iPhone 12 back camera"));
+      QCOMPARE(model.recordAt(model.rowOf(video)).camera, QStringLiteral("Apple iPhone 12"));
+      QVERIFY(model.recordAt(model.rowOf(undated)).camera.isEmpty());
+      QVERIFY(model.recordAt(model.rowOf(capture)).camera.isEmpty());
 
       // A result for an older version of the file cannot reorder the live row.
-      model.applyCapturedDates({{photo, 0, 0, QDateTime(QDate(1990, 1, 1), QTime(0, 0)), 0, 0}});
+      model.applyMetadata({{photo, 0, 0, QDateTime(QDate(1990, 1, 1), QTime(0, 0)), 0, 0}});
       QCOMPARE(model.recordAt(model.rowOf(photo)).captured,
                QDateTime(QDate(2020, 5, 6), QTime(7, 8, 9)));
       // Embedded metadata can never override a producer timestamp.
       const CaptureRecord& producer = model.recordAt(model.rowOf(capture));
-      model.applyCapturedDates(
+      model.applyMetadata(
           {{capture, producer.modified, producer.bytes, QDateTime(QDate(1990, 1, 1), QTime(0, 0)),
             producer.device, producer.inode}});
       QCOMPARE(model.recordAt(model.rowOf(capture)).captured,
@@ -2137,6 +2212,7 @@ private slots:
                QDateTime(QDate(2020, 5, 6), QTime(7, 8, 9)));
       QCOMPARE(model.recordAt(model.rowOf(video)).captured,
                QDateTime(QDate(2021, 8, 9), QTime(10, 11, 12)));
+      QCOMPARE(model.recordAt(model.rowOf(photo)).camera, QStringLiteral("Apple iPhone 12"));
     }
 
     QFile firstLog(logPath);
@@ -2145,18 +2221,25 @@ private slots:
     firstLog.close();
     QCOMPARE(firstRuns.count("image\n"), 1);
     QCOMPARE(firstRuns.count("video\n"), 1);
-    const QFileInfo dateCache(MediaDateIndex::cachePath());
+    const QFileInfo dateCache(MediaMetadataIndex::cachePath());
     QVERIFY(dateCache.isFile());
     const QFileDevice::Permissions publicPermissions =
         QFileDevice::ReadGroup | QFileDevice::WriteGroup | QFileDevice::ExeGroup |
         QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther;
     QCOMPARE(dateCache.permissions() & publicPermissions, QFileDevice::Permissions());
 
-    // The second index applies its private cache and starts no process.
+    // The second index applies its private cache and starts no process. A
+    // fresh model gets its cameras from that cache too.
     {
-      MediaDateIndex cached(&model);
+      CaptureModel fresh(&settings);
+      QSignalSpy freshScan(&fresh, &CaptureModel::countChanged);
+      QVERIFY(freshScan.wait(5000));
+      MediaMetadataIndex cached(&fresh);
       QTest::qWait(300);
       QVERIFY(!cached.indexing());
+      QCOMPARE(fresh.recordAt(fresh.rowOf(photo)).camera, QStringLiteral("Apple iPhone 12"));
+      QCOMPARE(fresh.recordAt(fresh.rowOf(photo)).captured,
+               QDateTime(QDate(2020, 5, 6), QTime(7, 8, 9)));
     }
     QFile secondLog(logPath);
     QVERIFY(secondLog.open(QIODevice::ReadOnly));
@@ -2238,7 +2321,7 @@ private slots:
     QSignalSpy dateChanges(&model, &QAbstractItemModel::dataChanged);
 
     {
-      MediaDateIndex dates(&model);
+      MediaMetadataIndex dates(&model);
       QTRY_COMPARE_WITH_TIMEOUT(dates.total(), paths.size(), 2000);
       QTRY_VERIFY_WITH_TIMEOUT(!dates.indexing(), 5000);
       QCOMPARE(dates.completed(), paths.size());

--- a/tests/tst_ui.cpp
+++ b/tests/tst_ui.cpp
@@ -18,7 +18,7 @@
 #include "library/CaptureFilterModel.h"
 #include "library/CaptureModel.h"
 #include "library/DuplicateIndex.h"
-#include "library/MediaDateIndex.h"
+#include "library/MediaMetadataIndex.h"
 #include "library/MediaInspector.h"
 #include "library/SimilarityIndex.h"
 #include "matte/MatteComposer.h"
@@ -143,7 +143,7 @@ private slots:
             [this] { m_library->setSimilarGroups(m_similarities->groups()); });
     m_mediaInfo = new MediaInspector(this);
     m_pdfInfo = new PdfInspector(this);
-    m_mediaDates = new MediaDateIndex(nullptr, this);
+    m_mediaMetadata = new MediaMetadataIndex(nullptr, this);
     m_actions = new ActionLauncher(this);
     m_registry = new ActionRegistry(m_actions, this);
     m_tailscale = new TailscalePeers(this);
@@ -195,7 +195,7 @@ private slots:
     context->setContextProperty(QStringLiteral("Similarities"), m_similarities);
     context->setContextProperty(QStringLiteral("MediaInfo"), m_mediaInfo);
     context->setContextProperty(QStringLiteral("PdfInfo"), m_pdfInfo);
-    context->setContextProperty(QStringLiteral("MediaDates"), m_mediaDates);
+    context->setContextProperty(QStringLiteral("MediaMetadata"), m_mediaMetadata);
     context->setContextProperty(QStringLiteral("Tailscale"), m_tailscale);
     context->setContextProperty(QStringLiteral("DemoMode"), true);
     context->setContextProperty(QStringLiteral("InitialPaths"), QStringList());
@@ -1122,14 +1122,14 @@ private slots:
     const CaptureRecord record = m_captures->recordAt(sourceRow);
     QVERIFY(!record.hasProducerTimestamp);
     const QDateTime enriched = record.captured.addSecs(-61);
-    m_captures->applyCapturedDates(
+    m_captures->applyMetadata(
         {{path, record.modified, record.bytes, enriched, record.device, record.inode}});
     QTRY_COMPARE(detail->property("dayLabel").toString(),
                  m_captures->dayLabelAt(m_captures->rowOf(path)));
     QTRY_COMPARE(detail->property("timeLabel").toString(),
                  m_library->timeLabelAt(m_library->rowOf(path)));
 
-    m_captures->applyCapturedDates(
+    m_captures->applyMetadata(
         {{path, record.modified, record.bytes, record.captured, record.device, record.inode}});
     QTRY_COMPARE(detail->property("timeLabel").toString(),
                  m_library->timeLabelAt(m_library->rowOf(path)));
@@ -1154,14 +1154,14 @@ private slots:
     const int sourceRow = m_captures->rowOf(selectedPath);
     const CaptureRecord record = m_captures->recordAt(sourceRow);
     const QDateTime moved = QDateTime::currentDateTime().addDays(1);
-    m_captures->applyCapturedDates(
+    m_captures->applyMetadata(
         {{selectedPath, record.modified, record.bytes, moved, record.device, record.inode}});
 
     QTRY_VERIFY(!reordered.isEmpty());
     QTRY_COMPARE(m_library->rowOf(selectedPath), 0);
     QTRY_COMPARE(pathAt(grid->property("currentIndex").toInt()), selectedPath);
 
-    m_captures->applyCapturedDates({{selectedPath, record.modified, record.bytes, record.captured,
+    m_captures->applyMetadata({{selectedPath, record.modified, record.bytes, record.captured,
                                      record.device, record.inode}});
     QTRY_COMPARE(pathAt(grid->property("currentIndex").toInt()), selectedPath);
   }
@@ -1962,11 +1962,11 @@ private slots:
     const QString movedPath = pathAt(movable);
     const CaptureRecord movedRecord = m_captures->recordAt(m_captures->rowOf(movedPath));
     const auto restoreDate = qScopeGuard([&] {
-      m_captures->applyCapturedDates({{movedPath, movedRecord.modified, movedRecord.bytes,
+      m_captures->applyMetadata({{movedPath, movedRecord.modified, movedRecord.bytes,
                                        movedRecord.captured, movedRecord.device,
                                        movedRecord.inode}});
     });
-    m_captures->applyCapturedDates({{movedPath, movedRecord.modified, movedRecord.bytes,
+    m_captures->applyMetadata({{movedPath, movedRecord.modified, movedRecord.bytes,
                                      QDateTime::currentDateTime().addYears(80), movedRecord.device,
                                      movedRecord.inode}});
     QTRY_COMPARE(m_library->rowOf(movedPath), 0);
@@ -2222,7 +2222,7 @@ private:
   SimilarityIndex* m_similarities = nullptr;
   MediaInspector* m_mediaInfo = nullptr;
   PdfInspector* m_pdfInfo = nullptr;
-  MediaDateIndex* m_mediaDates = nullptr;
+  MediaMetadataIndex* m_mediaMetadata = nullptr;
   ThumbnailProvider* m_thumbnails = nullptr;
   MatteProvider* m_mattes = nullptr;
   PdfProvider* m_pdfs = nullptr;


### PR DESCRIPTION
The metadata pass that reads embedded capture dates now records the camera and lens as well, from EXIF Make, Model and LensModel for images and the QuickTime make and model tags for videos. Nothing else changes about when the pass runs: it still skips Omarchy captures, batches images through one ImageMagick process and caches results by file identity. The cache moves to media-metadata.index with a new version so old caches are simply rebuilt.

Browse gets a Cameras section listing cameras and lenses with counts, most used first. The section only appears when the library has at least one file with camera details, so a screenshot library looks the same as before. The filter bar shows the chosen camera or lens, saved views keep the choice, and clearing the view resets it.

MediaDateIndex is renamed to MediaMetadataIndex since it no longer reads only dates. CaptureRecord carries camera and lens, the model exposes them as roles, and the filter model has cameraFilter, lensFilter, cameras and lenses.

Tests cover name normalization, image and video parsing, end to end indexing including the cache restart, the filter and the saved view round trip. Core and UI suites pass in the sandbox.

Linear: SBS-1139 item 1
