### PR TITLE
Add star ratings with a minimum rating filter and top rated sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Browse a photo library by camera and lens. The metadata pass that reads
   capture dates now records the camera and lens too, and saved views keep
   the choice. Libraries without camera photos do not show the section.
+- Star ratings. Rate a file from the viewer or with Alt+1 to Alt+5, sort by
+  Top rated, and narrow any view to a minimum rating from Browse. Saved views
+  keep the choice.
 
 ## 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ on them.
 - **Browses time directly.** Open a month or day, jump to today or this week,
   find recently modified files, or see what changed since the previous visit.
 - **Saves useful views.** Any combination of search, kind, folder, date, tag,
-  favourites, hidden files, and sort order can become a smart collection that
+  favourites, minimum rating, hidden files, and sort order can become a smart collection that
   updates as files change.
 - **Browses by camera.** Photos and videos with embedded camera details can
   be filtered by camera or lens from Browse, and a saved view remembers the
   choice. A library of screenshots never shows the section.
+- **Rates what matters.** Give any file one to five stars from the viewer or
+  with `Alt+1` to `Alt+5`, sort by rating, and narrow any view to a minimum
+  rating. Ratings are stored with favourites and never touch the file.
 - **Adds lightweight tags.** Tag any selection and browse it without moving or
   copying files. Tags follow in-app renames and can be combined with saved views.
 - **Knows what each file is.** Omarchy stamps its captures with a predictable
@@ -176,6 +179,7 @@ and put on your clipboard.
 | `Y` · `S` · `F` | Clipboard · Send · Show in files |
 | `V` · `Ctrl+H` | Favourite · Hide |
 | `1`-`8` · `Tab` `Shift+Tab` | Jump to a section · next · previous section |
+| `Alt+1`-`Alt+5` · `Alt+0` | Rate · clear rating, in the grid or the viewer |
 | `Page Up` `Page Down` in a PDF preview | Previous · next page |
 | `X` · `Ctrl+A` | Select · Select all |
 | with a selection | `V` `Ctrl+H` `Y` `S` `Del` act on every checked file |

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -308,6 +308,7 @@ ApplicationWindow {
         Captures.setTagFilter("", [])
         Captures.cameraFilter = ""
         Captures.lensFilter = ""
+        Captures.minimumRating = 0
         Captures.clearSmartCollection()
         Captures.setAlbumFilter("", [])
         Captures.folderFilter = folder === undefined ? "" : folder
@@ -432,6 +433,19 @@ ApplicationWindow {
             return row >= 0 && Captures.isDocumentAt(row)
         })
     }
+    // Stars go to the file in the viewer, else the selection, else the
+    // highlighted tile. Zero clears.
+    function rate(stars) {
+        const paths = detail.visible ? [detail.path]
+                      : library.checkedCount > 0 ? library.checkedPaths()
+                                                 : [root.currentPath()]
+        if (paths.length === 0 || paths[0] === "") {
+            return
+        }
+        Settings.setRating(paths, stars)
+        root.say(stars > 0 ? "Rated " + "★".repeat(stars)
+                           : "Rating cleared")
+    }
     function markChecked(which) {
         const paths = library.checkedPaths()
         if (which === "favorite") {
@@ -451,6 +465,7 @@ ApplicationWindow {
             // The star in the viewer's sidebar follows a favourite toggled
             // while it is open.
             detail.favorite = Settings.isFavorite(detail.path)
+            detail.rating = Settings.rating(detail.path)
         }
     }
 
@@ -817,6 +832,7 @@ ApplicationWindow {
         detail.sizeLabel = Captures.sizeLabelAt(index)
         detail.stamp = Captures.stampAt(index)
         detail.favorite = Settings.isFavorite(detail.path)
+        detail.rating = Settings.rating(detail.path)
         detail.canNavigate = root.adjacentViewerPath(detail.path, 1) !== ""
         detail.open()
         if (detail.isVideo || detail.isDocument) {
@@ -984,6 +1000,7 @@ ApplicationWindow {
 
     DetailSheet {
         id: detail
+        onRateRequested: function (stars) { root.rate(stars) }
         objectName: "detail"
         selectionLabel: root.viewerPaths.indexOf(detail.path) < 0 ? ""
                         : (root.viewerPaths.indexOf(detail.path) + 1)
@@ -1449,6 +1466,21 @@ ApplicationWindow {
         sequences: ["Shift+Tab", "Backtab", "Shift+Backtab"]
         enabled: !root.anySheetOpen && !root.popupOpen && !filters.searchActive
         onActivated: filters.cycleSection(-1)
+    }
+    // Alt with a digit rates. Plain digits already jump between sections,
+    // and the viewer keeps 0 and 1 for zoom, so the modifier is the same in
+    // both places.
+    Repeater {
+        model: 6
+        Item {
+            id: ratingKey
+            required property int index
+            Shortcut {
+                sequences: ["Alt+" + ratingKey.index]
+                enabled: !root.modalOpen && !root.popupOpen && !filters.searchActive
+                onActivated: root.rate(ratingKey.index)
+            }
+        }
     }
     Shortcut {
         sequences: ["Ctrl+A"]

--- a/qml/components/CaptureCard.qml
+++ b/qml/components/CaptureCard.qml
@@ -17,6 +17,7 @@ Item {
     // in-memory pixmap cache as well as the disk one.
     property double stamp: 0
     property bool favorite: false
+    property int rating: 0
     property bool hiddenMark: false
     property bool selected: false
     property bool checked: false
@@ -207,6 +208,18 @@ Item {
             font.pixelSize: 10
             color: "#ffffff"
             opacity: 0.90
+        }
+
+        // Stars sit at the right end of the strip, so they read with the
+        // time and size rather than competing with the picture.
+        Text {
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            anchors.margins: 8
+            visible: root.rating > 0
+            text: "★".repeat(root.rating)
+            font.pixelSize: 11
+            color: root.thumbnailReady ? Theme.yellow : Theme.foreground
         }
 
         Row {

--- a/qml/components/CaptureGrid.qml
+++ b/qml/components/CaptureGrid.qml
@@ -280,6 +280,7 @@ FocusScope {
             required property bool isVideo
             required property bool isDocument
             required property bool favorite
+            required property int rating
             required property bool hidden
             required property double stamp
             required property string ocrSnippet
@@ -301,6 +302,7 @@ FocusScope {
                 isDocument: cell.isDocument
                 stamp: cell.stamp
                 favorite: cell.favorite
+                rating: cell.rating
                 hiddenMark: cell.hidden
                 ocrSnippet: cell.ocrSnippet
                 selected: grid.currentIndex === cell.index

--- a/qml/components/DetailSheet.qml
+++ b/qml/components/DetailSheet.qml
@@ -28,6 +28,7 @@ Item {
     property int pdfPage: 1
     property double stamp: 0
     property bool favorite: false
+    property int rating: 0
     property int kind: 0
     property string playbackError: ""
     property bool canNavigate: false
@@ -113,6 +114,7 @@ Item {
     }
 
     signal actionTriggered(string id)
+    signal rateRequested(int stars)
     signal navigateRequested(int direction)
     signal fullScreenRequested(bool enabled)
 
@@ -1297,6 +1299,32 @@ Item {
                     font.family: Theme.fontFamily
                     font.pixelSize: 11
                     color: Theme.mutedText
+                }
+
+                // Rating. Click a star to set it, or the lit star again to
+                // clear. Alt+1 to Alt+5 and Alt+0 do the same from the keyboard.
+                Row {
+                    objectName: "viewerRating"
+                    spacing: 2
+
+                    Repeater {
+                        model: 5
+
+                        Text {
+                            required property int index
+                            readonly property bool lit: index < root.rating
+                            text: "★"
+                            font.pixelSize: 15
+                            color: lit ? Theme.yellow : root.shade(Theme.foreground, 0.28)
+                            Accessible.role: Accessible.Button
+                            Accessible.name: (index + 1) + (index === 0 ? " star" : " stars")
+
+                            TapHandler {
+                                onTapped: root.rateRequested(index + 1 === root.rating
+                                                             ? 0 : index + 1)
+                            }
+                        }
+                    }
                 }
 
                 Repeater {

--- a/qml/components/FilterBar.qml
+++ b/qml/components/FilterBar.qml
@@ -48,7 +48,8 @@ Item {
         Captures.kindFilter = kinds[(current + step + kinds.length) % kinds.length]
     }
 
-    readonly property var sortLabels: ["Newest", "Oldest", "Largest", "Smallest", "Name"]
+    readonly property var sortLabels: ["Newest", "Oldest", "Largest", "Smallest", "Name",
+                                       "Top rated"]
 
     // True while the search field owns the keyboard, so window-level
     // shortcuts that the field would not swallow (Escape, Ctrl+H) stand down.
@@ -160,6 +161,8 @@ Item {
                       : Captures.tagFilter !== "" ? "#" + Captures.tagFilter + "  ▾"
                       : Captures.cameraFilter !== "" ? Captures.cameraFilter + "  ▾"
                       : Captures.lensFilter !== "" ? Captures.lensFilter + "  ▾"
+                      : Captures.minimumRating > 0
+                        ? "★".repeat(Captures.minimumRating) + "+  ▾"
                       : Captures.dateFrom !== "" || Captures.modifiedAfter !== "" ? "Date  ▾"
                       : Captures.albumFilter !== "" ? Captures.albumFilter + "  ▾"
                       : Captures.folderFilter !== ""
@@ -168,6 +171,7 @@ Item {
                     || Captures.duplicatesOnly
                     || Captures.similarOnly || Captures.tagFilter !== ""
                     || Captures.cameraFilter !== "" || Captures.lensFilter !== ""
+                    || Captures.minimumRating > 0
                     || Captures.dateFrom !== "" || Captures.modifiedAfter !== ""
                     || Captures.smartCollectionFilter !== ""
                     || root.browserOpen

--- a/qml/components/LibraryBrowserSheet.qml
+++ b/qml/components/LibraryBrowserSheet.qml
@@ -95,6 +95,7 @@ FocusScope {
         Captures.setTagFilter("", [])
         Captures.cameraFilter = ""
         Captures.lensFilter = ""
+        Captures.minimumRating = 0
         Captures.clearDateRange()
         Captures.clearSmartCollection()
     }
@@ -358,6 +359,7 @@ FocusScope {
                             && Captures.tagFilter === "" && Captures.dateFrom === ""
                             && Captures.dateTo === "" && Captures.modifiedAfter === ""
                             && Captures.cameraFilter === "" && Captures.lensFilter === ""
+                            && Captures.minimumRating === 0
                             && Captures.smartCollectionFilter === ""
                             && !Captures.duplicatesOnly && !Captures.similarOnly
                     onClicked: root.showAll()
@@ -391,6 +393,35 @@ FocusScope {
                     onClicked: {
                         root.close()
                         root.saveSmartCollectionRequested()
+                    }
+                }
+            }
+
+            // A minimum rating narrows whatever else is chosen, the way the
+            // kind pills do, so picking one leaves the sheet open. The row
+            // only appears once something has been rated.
+            Flow {
+                width: parent.width
+                spacing: 7
+                visible: Settings.ratedCount > 0 || Captures.minimumRating > 0
+
+                Text {
+                    height: 26
+                    verticalAlignment: Text.AlignVCenter
+                    text: "Rated at least"
+                    font.family: Theme.fontFamily
+                    font.pixelSize: 11
+                    color: Theme.mutedText
+                }
+
+                Repeater {
+                    model: 5
+
+                    PillButton {
+                        required property int index
+                        label: "★".repeat(index + 1)
+                        active: Captures.minimumRating === index + 1
+                        onClicked: Captures.minimumRating = active ? 0 : index + 1
                     }
                 }
             }

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -15,6 +15,9 @@
 namespace {
 constexpr auto kFavorites = "library/favorites";
 constexpr auto kHidden = "library/hidden";
+// One "stars:path" entry per rated file, so the ini stays readable by hand.
+constexpr auto kRatings = "library/ratings";
+constexpr int kMaximumRating = 5;
 constexpr auto kShowHidden = "library/showHidden";
 constexpr auto kSortMode = "library/sortMode";
 constexpr auto kKindFilter = "library/kindFilter";
@@ -95,8 +98,19 @@ AppSettings::AppSettings(QObject* parent)
   const QStringList hidden = m_settings.value(kHidden).toStringList();
   m_hidden = QSet<QString>(hidden.begin(), hidden.end());
 
+  const QStringList ratings = m_settings.value(kRatings).toStringList();
+  for (const QString& entry : ratings) {
+    const qsizetype colon = entry.indexOf(QLatin1Char(':'));
+    bool okay = false;
+    const int stars = colon > 0 ? entry.first(colon).toInt(&okay) : 0;
+    const QString path = colon > 0 ? entry.sliced(colon + 1) : QString();
+    if (okay && stars >= 1 && stars <= kMaximumRating && !path.isEmpty()) {
+      m_ratings.insert(path, stars);
+    }
+  }
+
   m_showHidden = m_settings.value(kShowHidden, false).toBool();
-  m_sortMode = qBound(0, m_settings.value(kSortMode, 0).toInt(), 4);
+  m_sortMode = qBound(0, m_settings.value(kSortMode, 0).toInt(), 5);
   m_kindFilter = qBound(-1, m_settings.value(kKindFilter, -1).toInt(), 5);
   m_scanDownloads = m_settings.value(kScanDownloads, true).toBool();
   m_recursionDepth = qBound(1, m_settings.value(kRecursionDepth, 4).toInt(), 8);
@@ -186,9 +200,9 @@ void AppSettings::setShowHidden(bool value) {
 }
 
 void AppSettings::setSortMode(int value) {
-  // Five modes; an ini edited by hand or by an older version must not leave
+  // Six modes; an ini edited by hand or by an older version must not leave
   // the sort menu reading "undefined".
-  const int bounded = qBound(0, value, 4);
+  const int bounded = qBound(0, value, 5);
   if (m_sortMode == bounded) {
     return;
   }
@@ -308,6 +322,10 @@ void AppSettings::relocatePath(const QString& oldPath, const QString& newPath) {
   }
   if (m_hidden.remove(oldPath)) {
     m_hidden.insert(newPath);
+    marksChangedValue = true;
+  }
+  if (const int stars = m_ratings.take(oldPath); stars > 0) {
+    m_ratings.insert(newPath, stars);
     marksChangedValue = true;
   }
   if (marksChangedValue) {
@@ -783,6 +801,29 @@ void AppSettings::toggleFavorite(const QString& path) {
   emit marksChanged();
 }
 
+int AppSettings::rating(const QString& path) const { return m_ratings.value(path, 0); }
+
+void AppSettings::setRating(const QStringList& paths, int rating) {
+  const int stars = qBound(0, rating, kMaximumRating);
+  bool changed = false;
+  for (const QString& path : paths) {
+    if (path.isEmpty()) {
+      continue;
+    }
+    if (stars == 0) {
+      changed = m_ratings.remove(path) > 0 || changed;
+    } else if (m_ratings.value(path, 0) != stars) {
+      m_ratings.insert(path, stars);
+      changed = true;
+    }
+  }
+  if (!changed) {
+    return;
+  }
+  persistMarks();
+  emit marksChanged();
+}
+
 void AppSettings::toggleHidden(const QString& path) {
   if (path.isEmpty()) {
     return;
@@ -824,6 +865,9 @@ void AppSettings::setHidden(const QStringList& paths, bool on) {
 QStringList AppSettings::markedPaths() const {
   QSet<QString> all = m_favorites;
   all.unite(m_hidden);
+  for (auto it = m_ratings.cbegin(); it != m_ratings.cend(); ++it) {
+    all.insert(it.key());
+  }
   return QStringList(all.begin(), all.end());
 }
 
@@ -832,6 +876,7 @@ void AppSettings::forgetMarks(const QStringList& paths) {
   for (const QString& path : paths) {
     changed = m_favorites.remove(path) || changed;
     changed = m_hidden.remove(path) || changed;
+    changed = m_ratings.remove(path) > 0 || changed;
   }
   if (changed) {
     persistMarks();
@@ -841,4 +886,11 @@ void AppSettings::forgetMarks(const QStringList& paths) {
 void AppSettings::persistMarks() {
   m_settings.setValue(kFavorites, QStringList(m_favorites.begin(), m_favorites.end()));
   m_settings.setValue(kHidden, QStringList(m_hidden.begin(), m_hidden.end()));
+  QStringList ratings;
+  ratings.reserve(m_ratings.size());
+  for (auto it = m_ratings.cbegin(); it != m_ratings.cend(); ++it) {
+    ratings.append(QString::number(it.value()) + QLatin1Char(':') + it.key());
+  }
+  ratings.sort();
+  m_settings.setValue(kRatings, ratings);
 }

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -18,12 +18,15 @@ struct CaptureRecord;
 // defaults, never to make the app work, so nothing here is required for a first
 // run to show a full library.
 //
-// Favourites and hidden entries are keyed by absolute path. A file that moves
-// loses its mark, which is the honest behaviour for a library that never
+// Favourites, ratings and hidden entries are keyed by absolute path. A file
+// that moves loses its mark, which is the honest behaviour for a library that never
 // modifies or tracks the files it reads.
 class AppSettings final : public QObject {
   Q_OBJECT
   Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
+  // How many files carry a rating, so the Browse sheet can leave the rating
+  // row out of a library nobody has rated.
+  Q_PROPERTY(int ratedCount READ ratedCount NOTIFY marksChanged)
   Q_PROPERTY(int sortMode READ sortMode WRITE setSortMode NOTIFY sortModeChanged)
   Q_PROPERTY(int kindFilter READ kindFilter WRITE setKindFilter NOTIFY kindFilterChanged)
   Q_PROPERTY(
@@ -115,6 +118,11 @@ public:
   Q_INVOKABLE void toggleFavorite(const QString& path);
   Q_INVOKABLE void toggleHidden(const QString& path);
 
+  // Stars, 1 to 5. Zero is unrated and is not stored.
+  Q_INVOKABLE [[nodiscard]] int rating(const QString& path) const;
+  Q_INVOKABLE void setRating(const QStringList& paths, int rating);
+  [[nodiscard]] int ratedCount() const { return static_cast<int>(m_ratings.size()); }
+
   // Keep user-owned organization attached when an explicit in-app rename
   // changes the path. Discovery itself remains read-only.
   Q_INVOKABLE void relocatePath(const QString& oldPath, const QString& newPath);
@@ -171,6 +179,7 @@ private:
   QSettings m_settings;
   QSet<QString> m_favorites;
   QSet<QString> m_hidden;
+  QHash<QString, int> m_ratings;
 
   bool m_showHidden = false;
   int m_sortMode = 0;

--- a/src/library/CaptureFilterModel.cpp
+++ b/src/library/CaptureFilterModel.cpp
@@ -527,6 +527,19 @@ void CaptureFilterModel::setLensFilter(const QString& lens) {
   emit countChanged();
 }
 
+void CaptureFilterModel::setMinimumRating(int stars) {
+  const int bounded = qBound(0, stars, 5);
+  if (m_minimumRating == bounded) {
+    return;
+  }
+  beginFilterUpdate();
+  m_minimumRating = bounded;
+  endFilterUpdate();
+  clearSmartCollection();
+  emit minimumRatingChanged();
+  emit countChanged();
+}
+
 QVariantMap CaptureFilterModel::currentView() const {
   QVariantMap view;
   view.insert(QStringLiteral("search"), m_searchText);
@@ -541,6 +554,7 @@ QVariantMap CaptureFilterModel::currentView() const {
   view.insert(QStringLiteral("tag"), m_tagFilter);
   view.insert(QStringLiteral("camera"), m_cameraFilter);
   view.insert(QStringLiteral("lens"), m_lensFilter);
+  view.insert(QStringLiteral("minRating"), m_minimumRating);
   view.insert(QStringLiteral("sort"), m_sortMode);
   return view;
 }
@@ -565,8 +579,9 @@ void CaptureFilterModel::applyView(const QString& name, const QVariantMap& view,
   m_tagPaths = QSet<QString>(tagPaths.begin(), tagPaths.end());
   m_cameraFilter = view.value(QStringLiteral("camera")).toString();
   m_lensFilter = view.value(QStringLiteral("lens")).toString();
+  m_minimumRating = qBound(0, view.value(QStringLiteral("minRating")).toInt(), 5);
   m_sortMode = qBound(0, view.value(QStringLiteral("sort"), NewestFirst).toInt(),
-                      static_cast<int>(NameAscending));
+                      static_cast<int>(RatingFirst));
   m_albumFilter.clear();
   m_albumPaths.clear();
   m_duplicatesOnly = false;
@@ -583,6 +598,7 @@ void CaptureFilterModel::applyView(const QString& name, const QVariantMap& view,
   emit tagFilterChanged();
   emit cameraFilterChanged();
   emit lensFilterChanged();
+  emit minimumRatingChanged();
   emit sortModeChanged();
   emit albumFilterChanged();
   emit duplicatesOnlyChanged();
@@ -878,6 +894,11 @@ bool CaptureFilterModel::recordLessThan(const CaptureRecord& first,
       return names < 0;
     }
     return pathOrder();
+  case RatingFirst:
+    if (first.rating != second.rating) {
+      return first.rating > second.rating;
+    }
+    return first.captured != second.captured ? first.captured > second.captured : pathOrder();
   case NewestFirst:
   default:
     return first.captured != second.captured ? first.captured > second.captured : pathOrder();
@@ -942,6 +963,9 @@ bool CaptureFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex& sour
     return false;
   }
   if (m_favoritesOnly && !record.favorite) {
+    return false;
+  }
+  if (m_minimumRating > 0 && record.rating < m_minimumRating) {
     return false;
   }
   if (!m_albumFilter.isEmpty() && !m_albumPaths.contains(record.path)) {

--- a/src/library/CaptureFilterModel.h
+++ b/src/library/CaptureFilterModel.h
@@ -42,6 +42,8 @@ class CaptureFilterModel final : public QSortFilterProxyModel {
   Q_PROPERTY(QVariantList cameras READ cameras NOTIFY camerasChanged)
   Q_PROPERTY(QVariantList lenses READ lenses NOTIFY camerasChanged)
   Q_PROPERTY(
+      int minimumRating READ minimumRating WRITE setMinimumRating NOTIFY minimumRatingChanged)
+  Q_PROPERTY(
       QString smartCollectionFilter READ smartCollectionFilter NOTIFY smartCollectionFilterChanged)
   Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
   Q_PROPERTY(
@@ -60,6 +62,7 @@ public:
     LargestFirst,
     SmallestFirst,
     NameAscending,
+    RatingFirst,
   };
   Q_ENUM(SortMode)
 
@@ -112,6 +115,9 @@ public:
   void setLensFilter(const QString& lens);
   [[nodiscard]] QVariantList cameras() const { return m_cameras; }
   [[nodiscard]] QVariantList lenses() const { return m_lenses; }
+  // Stars a file needs to show. Zero shows everything, including unrated.
+  [[nodiscard]] int minimumRating() const { return m_minimumRating; }
+  void setMinimumRating(int stars);
 
   [[nodiscard]] QString smartCollectionFilter() const { return m_smartCollectionFilter; }
   Q_INVOKABLE QVariantMap currentView() const;
@@ -189,6 +195,7 @@ signals:
   void cameraFilterChanged();
   void lensFilterChanged();
   void camerasChanged();
+  void minimumRatingChanged();
   void smartCollectionFilterChanged();
   void showHiddenChanged();
   void duplicatesOnlyChanged();
@@ -234,6 +241,7 @@ private:
   QString m_lensFilter;
   QVariantList m_cameras;
   QVariantList m_lenses;
+  int m_minimumRating = 0;
   QString m_smartCollectionFilter;
   bool m_favoritesOnly = false;
   bool m_showHidden = false;

--- a/src/library/CaptureModel.cpp
+++ b/src/library/CaptureModel.cpp
@@ -282,6 +282,8 @@ QVariant CaptureModel::data(const QModelIndex& index, int role) const {
     return record.camera;
   case CaptureRoles::LensRole:
     return record.lens;
+  case CaptureRoles::RatingRole:
+    return record.rating;
   default:
     return {};
   }
@@ -306,6 +308,7 @@ QHash<int, QByteArray> CaptureModel::roleNames() const {
       {CaptureRoles::HiddenRole, "hidden"},
       {CaptureRoles::CameraRole, "camera"},
       {CaptureRoles::LensRole, "lens"},
+      {CaptureRoles::RatingRole, "rating"},
   };
 }
 
@@ -467,6 +470,7 @@ void CaptureModel::adoptResults(ScanResult result) {
     for (CaptureRecord& record : scanned) {
       record.favorite = m_settings->isFavorite(record.path);
       record.hidden = m_settings->isHidden(record.path);
+      record.rating = m_settings->rating(record.path);
     }
   }
 
@@ -607,13 +611,17 @@ void CaptureModel::applyMarks() {
     CaptureRecord& record = m_records[row];
     const bool favorite = m_settings->isFavorite(record.path);
     const bool hidden = m_settings->isHidden(record.path);
-    if (favorite == record.favorite && hidden == record.hidden) {
+    const int rating = m_settings->rating(record.path);
+    if (favorite == record.favorite && hidden == record.hidden && rating == record.rating) {
       continue;
     }
     record.favorite = favorite;
     record.hidden = hidden;
+    record.rating = rating;
     const QModelIndex changed = index(static_cast<int>(row), 0);
-    emit dataChanged(changed, changed, {CaptureRoles::FavoriteRole, CaptureRoles::HiddenRole});
+    emit dataChanged(changed, changed,
+                     {CaptureRoles::FavoriteRole, CaptureRoles::HiddenRole,
+                      CaptureRoles::RatingRole});
   }
 }
 

--- a/src/library/CaptureRecord.h
+++ b/src/library/CaptureRecord.h
@@ -51,6 +51,8 @@ struct CaptureRecord {
   // them, so discovery stays a pure function of the filesystem.
   bool favorite = false;
   bool hidden = false;
+  // Stars, 1 to 5; zero is unrated.
+  int rating = 0;
 
   [[nodiscard]] bool isVideo() const { return video; }
   [[nodiscard]] bool isDocument() const { return document || kind == Document; }

--- a/src/library/CaptureRoles.h
+++ b/src/library/CaptureRoles.h
@@ -24,6 +24,7 @@ enum Role {
   HiddenRole,
   CameraRole,
   LensRole,
+  RatingRole,
   // Added by CaptureFilterModel while a search result needs OCR context.
   OcrSnippetRole,
 };

--- a/tests/tst_omaroll.cpp
+++ b/tests/tst_omaroll.cpp
@@ -1209,6 +1209,30 @@ private slots:
     proxy.clearSmartCollection();
     proxy.setCameraFilter({});
     proxy.setLensFilter({});
+
+    // Ratings come from the settings marks, filter by a minimum and sort
+    // highest first; a saved view keeps the minimum.
+    settings.setRating({beach}, 4);
+    QTRY_COMPARE_WITH_TIMEOUT(model.recordAt(model.rowOf(beach)).rating, 4, 1000);
+    proxy.setMinimumRating(3);
+    QCOMPARE(proxy.count(), 1);
+    QCOMPARE(proxy.pathAt(0), beach);
+    proxy.setMinimumRating(5);
+    QCOMPARE(proxy.count(), 0);
+    const QVariantMap ratedView = proxy.currentView();
+    QCOMPARE(ratedView.value(QStringLiteral("minRating")).toInt(), 5);
+    proxy.setMinimumRating(0);
+    QCOMPARE(proxy.count(), 5);
+    proxy.setSortMode(CaptureFilterModel::RatingFirst);
+    QCOMPARE(proxy.pathAt(0), beach);
+    proxy.setSortMode(CaptureFilterModel::NewestFirst);
+    proxy.applyView(QStringLiteral("Five stars"), ratedView);
+    QCOMPARE(proxy.minimumRating(), 5);
+    QCOMPARE(proxy.count(), 0);
+    proxy.clearSmartCollection();
+    proxy.setMinimumRating(0);
+    settings.setRating({beach}, 0);
+    QTRY_COMPARE_WITH_TIMEOUT(model.recordAt(model.rowOf(beach)).rating, 0, 1000);
     QCOMPARE(proxy.count(), 5);
 
     const QString forest = dir.filePath(QStringLiteral("album/forest.png"));
@@ -2716,6 +2740,9 @@ private slots:
     QVERIFY(settings.addToAlbum(album, {original}));
     settings.toggleFavorite(original);
     settings.toggleHidden(original);
+    settings.setRating({original}, 4);
+    QCOMPARE(settings.rating(original), 4);
+    QCOMPARE(settings.ratedCount(), 1);
 
     ActionLauncher launcher;
     QVERIFY(!launcher.renameFile(original, QString()).value(QStringLiteral("ok")).toBool());
@@ -2739,11 +2766,22 @@ private slots:
     settings.relocatePath(original, newPath);
     QVERIFY(settings.isFavorite(newPath));
     QVERIFY(settings.isHidden(newPath));
+    QCOMPARE(settings.rating(newPath), 4);
+    QCOMPARE(settings.rating(original), 0);
     QCOMPARE(settings.albumPaths(album), QStringList {newPath});
     AppSettings restored;
     QVERIFY(restored.isFavorite(newPath));
     QVERIFY(restored.isHidden(newPath));
+    QCOMPARE(restored.rating(newPath), 4);
     QCOMPARE(restored.albumPaths(album), QStringList {newPath});
+
+    // Out-of-range stars clamp, and zero forgets the entry entirely.
+    settings.setRating({newPath}, 9);
+    QCOMPARE(settings.rating(newPath), 5);
+    settings.setRating({newPath}, 0);
+    QCOMPARE(settings.rating(newPath), 0);
+    QCOMPARE(settings.ratedCount(), 0);
+    QVERIFY(!settings.markedPaths().contains(newPath) || settings.isFavorite(newPath));
 
     settings.toggleFavorite(newPath);
     settings.toggleHidden(newPath);

--- a/tests/tst_ui.cpp
+++ b/tests/tst_ui.cpp
@@ -19,6 +19,7 @@
 #include "library/CaptureModel.h"
 #include "library/DuplicateIndex.h"
 #include "library/MediaMetadataIndex.h"
+#include "library/CaptureRoles.h"
 #include "library/MediaInspector.h"
 #include "library/SimilarityIndex.h"
 #include "matte/MatteComposer.h"
@@ -735,6 +736,28 @@ private slots:
     // rather than sending an Escape that would now close the window.
     item("library")->forceActiveFocus();
     QTRY_VERIFY(item("library")->hasActiveFocus());
+  }
+
+  void altDigitsRateTheHighlightedTileAndTheViewer() {
+    item("library")->setProperty("currentIndex", 0);
+    item("library")->forceActiveFocus();
+    const QString first = pathAt(0);
+    QTest::keyClick(m_window, Qt::Key_3, Qt::AltModifier);
+    QTRY_COMPARE(m_settings->rating(first), 3);
+    QTRY_COMPARE(m_library->data(m_library->index(0, 0), CaptureRoles::RatingRole).toInt(), 3);
+
+    // The viewer shows the same stars and Alt+0 clears them there.
+    QQuickItem* detail = item("detail");
+    openDetail(0);
+    QTRY_VERIFY(detail->isVisible());
+    QTRY_COMPARE(detail->property("rating").toInt(), 3);
+    QTest::keyClick(m_window, Qt::Key_5, Qt::AltModifier);
+    QTRY_COMPARE(m_settings->rating(first), 5);
+    QTRY_COMPARE(detail->property("rating").toInt(), 5);
+    QTest::keyClick(m_window, Qt::Key_0, Qt::AltModifier);
+    QTRY_COMPARE(m_settings->rating(first), 0);
+    QTest::keyClick(m_window, Qt::Key_Escape);
+    QTRY_VERIFY(!detail->isVisible());
   }
 
   void exactDuplicatesOpenAsAGroupedReviewView() {


### PR DESCRIPTION
Files can carry one to five stars. Ratings live in the settings ini beside favourites and hidden marks as "stars:path" entries, follow in-app renames, and are forgotten with the other marks when a file is gone. Zero clears the entry rather than storing it.

In the grid the stars sit at the right end of the tile's bottom strip. The viewer shows a clickable star row under the file details; clicking the lit star clears. Alt+1 to Alt+5 rate and Alt+0 clears, in the grid (the selection, or the highlighted tile) and in the viewer. Plain digits still jump sections and the viewer keeps 0 and 1 for zoom.

Sort gains Top rated. Browse gains a "Rated at least" row of star pills that narrows the current view like the kind pills do, shown only once something has been rated. Saved views keep the minimum rating and the filter bar's Browse pill shows it.

Tests cover persistence, relocation and clamping in AppSettings, the filter, sort and saved view round trip, and the Alt+digit shortcuts in the grid and viewer. Core and UI suites pass in the sandbox.

Linear: SBS-1141
