### PR TITLE
Nest tags with a slash and add per-file captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Star ratings. Rate a file from the viewer or with Alt+1 to Alt+5, sort by
   Top rated, and narrow any view to a minimum rating from Browse. Saved views
   keep the choice.
+- Nested tags. A tag named Travel/Japan sits under Travel in Browse, and
+  choosing the parent shows everything beneath it.
+- Captions. Add a short caption in the viewer; it shows on the tile and is
+  searched with filenames and picture text.
 
 ## 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ on them.
   rating. Ratings are stored with favourites and never touch the file.
 - **Adds lightweight tags.** Tag any selection and browse it without moving or
   copying files. Tags follow in-app renames and can be combined with saved views.
+  Name a tag `Travel/Japan` to nest it under `Travel`; choosing the parent shows
+  everything beneath it.
+- **Captions files.** Type a caption in the viewer and it shows on the tile and
+  matches in search, alongside filenames and picture text. Captions are stored
+  with the other marks and never written into the file.
 - **Knows what each file is.** Omarchy stamps its captures with a predictable
   name, so a screenshot is a Screenshot even though it lives in `~/Pictures`
   next to every other image.

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -466,6 +466,7 @@ ApplicationWindow {
             // while it is open.
             detail.favorite = Settings.isFavorite(detail.path)
             detail.rating = Settings.rating(detail.path)
+            detail.caption = Settings.caption(detail.path)
         }
     }
 
@@ -833,6 +834,7 @@ ApplicationWindow {
         detail.stamp = Captures.stampAt(index)
         detail.favorite = Settings.isFavorite(detail.path)
         detail.rating = Settings.rating(detail.path)
+        detail.caption = Settings.caption(detail.path)
         detail.canNavigate = root.adjacentViewerPath(detail.path, 1) !== ""
         detail.open()
         if (detail.isVideo || detail.isDocument) {
@@ -1001,6 +1003,10 @@ ApplicationWindow {
     DetailSheet {
         id: detail
         onRateRequested: function (stars) { root.rate(stars) }
+        onCaptionEdited: function (text) {
+            Settings.setCaption(detail.path, text)
+            root.say(text !== "" ? "Caption saved" : "Caption removed")
+        }
         objectName: "detail"
         selectionLabel: root.viewerPaths.indexOf(detail.path) < 0 ? ""
                         : (root.viewerPaths.indexOf(detail.path) + 1)

--- a/qml/components/CaptureCard.qml
+++ b/qml/components/CaptureCard.qml
@@ -23,6 +23,7 @@ Item {
     property bool checked: false
     property bool selectionMode: false
     property string ocrSnippet: ""
+    property string caption: ""
     property bool thumbnailReady: false
     readonly property bool thumbnailPresented: thumbnail.status === Image.Ready
                                                && thumbnail.opacity >= 0.999
@@ -189,7 +190,7 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: parent.bottom
-            height: root.ocrSnippet !== "" ? 52 : 30
+            height: root.ocrSnippet !== "" || root.caption !== "" ? 52 : 30
             visible: root.thumbnailReady
             color: Qt.rgba(0, 0, 0, 0.72)
         }
@@ -201,8 +202,9 @@ Item {
             anchors.leftMargin: 8
             anchors.rightMargin: 8
             anchors.bottomMargin: 2
-            visible: root.ocrSnippet !== "" && root.thumbnailReady
-            text: root.ocrSnippet
+            // A search match outranks the caption on the one line there is.
+            visible: (root.ocrSnippet !== "" || root.caption !== "") && root.thumbnailReady
+            text: root.ocrSnippet !== "" ? root.ocrSnippet : root.caption
             elide: Text.ElideRight
             font.family: Theme.fontFamily
             font.pixelSize: 10

--- a/qml/components/CaptureGrid.qml
+++ b/qml/components/CaptureGrid.qml
@@ -284,6 +284,7 @@ FocusScope {
             required property bool hidden
             required property double stamp
             required property string ocrSnippet
+            required property string caption
 
             width: grid.cellWidth
             height: grid.cellHeight
@@ -305,6 +306,7 @@ FocusScope {
                 rating: cell.rating
                 hiddenMark: cell.hidden
                 ocrSnippet: cell.ocrSnippet
+                caption: cell.caption
                 selected: grid.currentIndex === cell.index
                 checked: root.isChecked(cell.path)
                 selectionMode: root.checkedCount > 0

--- a/qml/components/DetailSheet.qml
+++ b/qml/components/DetailSheet.qml
@@ -29,6 +29,7 @@ Item {
     property double stamp: 0
     property bool favorite: false
     property int rating: 0
+    property string caption: ""
     property int kind: 0
     property string playbackError: ""
     property bool canNavigate: false
@@ -115,6 +116,7 @@ Item {
 
     signal actionTriggered(string id)
     signal rateRequested(int stars)
+    signal captionEdited(string text)
     signal navigateRequested(int direction)
     signal fullScreenRequested(bool enabled)
 
@@ -1324,6 +1326,65 @@ Item {
                                                              ? 0 : index + 1)
                             }
                         }
+                    }
+                }
+
+                // Caption. Enter or leaving the field saves; Escape puts the
+                // saved text back and returns to the picture.
+                Rectangle {
+                    width: parent.width
+                    height: 26
+                    radius: Theme.cornerRadius > 0 ? Theme.cornerRadius : 3
+                    color: root.shade(Theme.foreground, captionField.activeFocus ? 0.10 : 0.05)
+                    border.width: 1
+                    border.color: captionField.activeFocus
+                                  ? root.shade(Theme.accent, 0.6)
+                                  : root.shade(Theme.foreground, 0.12)
+
+                    TextInput {
+                        id: captionField
+                        objectName: "viewerCaption"
+                        anchors.fill: parent
+                        anchors.leftMargin: 8
+                        anchors.rightMargin: 8
+                        verticalAlignment: TextInput.AlignVCenter
+                        clip: true
+                        activeFocusOnTab: false
+                        font.family: Theme.fontFamily
+                        font.pixelSize: 11
+                        color: Theme.foreground
+                        selectionColor: root.shade(Theme.accent, 0.5)
+                        selectedTextColor: Theme.brightForeground
+                        // Typing breaks a plain binding, so follow the saved
+                        // caption explicitly when the file or its marks change.
+                        readonly property string saved: root.caption
+                        onSavedChanged: text = saved
+                        Component.onCompleted: text = saved
+                        onEditingFinished: {
+                            if (text.trim() !== root.caption) {
+                                root.captionEdited(text.trim())
+                            }
+                        }
+                        Keys.onEscapePressed: {
+                            text = root.caption
+                            root.focusPreview()
+                        }
+                        Keys.onReturnPressed: root.focusPreview()
+                        Keys.onEnterPressed: root.focusPreview()
+                    }
+
+                    Text {
+                        anchors.fill: captionField
+                        verticalAlignment: Text.AlignVCenter
+                        visible: captionField.text === "" && !captionField.activeFocus
+                        text: "Add a caption"
+                        font.family: Theme.fontFamily
+                        font.pixelSize: 11
+                        color: root.shade(Theme.foreground, 0.35)
+                    }
+
+                    TapHandler {
+                        onTapped: captionField.forceActiveFocus()
                     }
                 }
 

--- a/qml/components/LibraryBrowserSheet.qml
+++ b/qml/components/LibraryBrowserSheet.qml
@@ -536,7 +536,9 @@ FocusScope {
                     visible: (root.section === 1 || root.section === 3 || root.section === 4)
                              && choices.currentIndex >= 0
                     label: "Delete selected"
-                    toolTip: "Remove this collection. Files are not deleted."
+                    toolTip: root.section === 3
+                             ? "Remove this tag and any tags nested under it. Files are not deleted."
+                             : "Remove this collection. Files are not deleted."
                     onClicked: root.deleteCurrentChoice()
                 }
             }
@@ -628,8 +630,13 @@ FocusScope {
                     readonly property bool objectChoice: dateChoice || cameraChoice
                     readonly property string value: objectChoice ? String(modelData.value)
                                                                       : String(modelData)
+                    // Tags draw as a tree while the whole list shows; a search
+                    // can hide a parent, so matches show their full path.
+                    readonly property int tagDepth: root.section === 3 && root.query === ""
+                                                    ? value.split("/").length - 1 : 0
                     readonly property string choiceLabel: objectChoice ? String(modelData.label)
-                                                                            : value
+                                                          : tagDepth > 0
+                                                            ? value.split("/").pop() : value
                     readonly property bool selectedChoice:
                         root.section === 0 ? Captures.folderFilter === value
                         : root.section === 1 ? Captures.albumFilter === value
@@ -666,7 +673,7 @@ FocusScope {
                             text: root.section === 0 ? root.nameForPath(choiceRow.value)
                                                      : choiceRow.choiceLabel
                             leftPadding: choiceRow.dateChoice && choiceRow.modelData.type === "day"
-                                         ? 18 : 0
+                                         ? 18 : 18 * choiceRow.tagDepth
                             elide: Text.ElideRight
                             font.family: Theme.fontFamily
                             font.pixelSize: 11
@@ -676,6 +683,7 @@ FocusScope {
 
                         Text {
                             width: parent.width
+                            leftPadding: 18 * choiceRow.tagDepth
                             text: root.section === 0
                                   ? root.contextForPath(choiceRow.value) + "  ·  "
                                     + root.formatCount(choiceRow.itemCount)

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -18,6 +18,8 @@ constexpr auto kHidden = "library/hidden";
 // One "stars:path" entry per rated file, so the ini stays readable by hand.
 constexpr auto kRatings = "library/ratings";
 constexpr int kMaximumRating = 5;
+constexpr auto kCaptions = "library/captions";
+constexpr int kMaximumCaptionLength = 500;
 constexpr auto kShowHidden = "library/showHidden";
 constexpr auto kSortMode = "library/sortMode";
 constexpr auto kKindFilter = "library/kindFilter";
@@ -51,6 +53,35 @@ QString normalizedFolder(const QString& path, bool mustExist) {
 QString normalizedAlbumName(const QString& name) {
   const QString normalized = name.simplified().left(60);
   return normalized.contains(QLatin1Char('/')) ? QString() : normalized;
+}
+
+// "travel / japan /" becomes "travel/japan". Empty segments are dropped, so
+// a stray slash cannot create a nameless level.
+QString normalizedTagName(const QString& name) {
+  QStringList segments;
+  for (const QString& part : name.split(QLatin1Char('/'))) {
+    const QString segment = part.simplified();
+    if (!segment.isEmpty()) {
+      segments.append(segment);
+    }
+  }
+  return segments.join(QLatin1Char('/')).left(80);
+}
+
+bool tagLessThan(const QString& first, const QString& second) {
+  const QStringList a = first.split(QLatin1Char('/'));
+  const QStringList b = second.split(QLatin1Char('/'));
+  for (qsizetype index = 0; index < qMin(a.size(), b.size()); ++index) {
+    if (const int order = a.at(index).compare(b.at(index), Qt::CaseInsensitive); order != 0) {
+      return order < 0;
+    }
+  }
+  return a.size() < b.size();
+}
+
+bool tagIsUnder(const QString& candidate, const QString& parent) {
+  return candidate.size() > parent.size() && candidate.startsWith(parent) &&
+         candidate.at(parent.size()) == QLatin1Char('/');
 }
 
 } // namespace
@@ -109,6 +140,14 @@ AppSettings::AppSettings(QObject* parent)
     }
   }
 
+  const QVariantMap captions = m_settings.value(kCaptions).toMap();
+  for (auto it = captions.cbegin(); it != captions.cend(); ++it) {
+    const QString text = it.value().toString().trimmed().left(kMaximumCaptionLength);
+    if (!it.key().isEmpty() && !text.isEmpty()) {
+      m_captions.insert(it.key(), text);
+    }
+  }
+
   m_showHidden = m_settings.value(kShowHidden, false).toBool();
   m_sortMode = qBound(0, m_settings.value(kSortMode, 0).toInt(), 5);
   m_kindFilter = qBound(-1, m_settings.value(kKindFilter, -1).toInt(), 5);
@@ -138,9 +177,10 @@ AppSettings::AppSettings(QObject* parent)
   m_slideshowVideos = m_settings.value(kSlideshowVideos, false).toBool();
   const QVariantMap storedAlbums = m_settings.value(kAlbums).toMap();
   const auto restoreCollections = [this](const QVariantMap& storedCollections,
-                                         QMap<QString, QList<AlbumEntry>>& target) {
+                                         QMap<QString, QList<AlbumEntry>>& target,
+                                         QString (*normalize)(const QString&)) {
     for (auto it = storedCollections.cbegin(); it != storedCollections.cend(); ++it) {
-      const QString name = normalizedAlbumName(it.key());
+      const QString name = normalize(it.key());
       if (name.isEmpty()) {
         continue;
       }
@@ -176,8 +216,8 @@ AppSettings::AppSettings(QObject* parent)
       target.insert(name, entries);
     }
   };
-  restoreCollections(storedAlbums, m_albums);
-  restoreCollections(m_settings.value(kTags).toMap(), m_tags);
+  restoreCollections(storedAlbums, m_albums, normalizedAlbumName);
+  restoreCollections(m_settings.value(kTags).toMap(), m_tags, normalizedTagName);
 
   const QVariantMap storedSmart = m_settings.value(kSmartCollections).toMap();
   for (auto it = storedSmart.cbegin(); it != storedSmart.cend(); ++it) {
@@ -326,6 +366,10 @@ void AppSettings::relocatePath(const QString& oldPath, const QString& newPath) {
   }
   if (const int stars = m_ratings.take(oldPath); stars > 0) {
     m_ratings.insert(newPath, stars);
+    marksChangedValue = true;
+  }
+  if (const QString text = m_captions.take(oldPath); !text.isEmpty()) {
+    m_captions.insert(newPath, text);
     marksChangedValue = true;
   }
   if (marksChangedValue) {
@@ -494,15 +538,25 @@ void AppSettings::removeUnavailableFromAlbum(const QString& name) {
 
 QStringList AppSettings::tagNames() const {
   QStringList names = m_tags.keys();
-  names.sort(Qt::CaseInsensitive);
+  std::sort(names.begin(), names.end(), tagLessThan);
   return names;
 }
 
 QStringList AppSettings::tagPaths(const QString& name) const {
   QStringList paths;
-  for (const AlbumEntry& entry : m_tags.value(name)) {
-    if (entry.resolved) {
-      paths.append(entry.path);
+  QSet<QString> seen;
+  const auto collect = [&](const QList<AlbumEntry>& entries) {
+    for (const AlbumEntry& entry : entries) {
+      if (entry.resolved && !seen.contains(entry.path)) {
+        paths.append(entry.path);
+        seen.insert(entry.path);
+      }
+    }
+  };
+  collect(m_tags.value(name));
+  for (auto it = m_tags.cbegin(); it != m_tags.cend(); ++it) {
+    if (tagIsUnder(it.key(), name)) {
+      collect(it.value());
     }
   }
   return paths;
@@ -522,11 +576,11 @@ QStringList AppSettings::tagsForPath(const QString& path) const {
 }
 
 int AppSettings::tagItemCount(const QString& name) const {
-  return static_cast<int>(m_tags.value(name).size());
+  return static_cast<int>(tagPaths(name).size());
 }
 
 bool AppSettings::createTag(const QString& name) {
-  const QString normalized = normalizedAlbumName(name);
+  const QString normalized = normalizedTagName(name);
   if (normalized.isEmpty()) {
     return false;
   }
@@ -535,14 +589,35 @@ bool AppSettings::createTag(const QString& name) {
       return false;
     }
   }
-  m_tags.insert(normalized, {});
+  // Every ancestor exists too, so the tree in Browse has no gaps and a
+  // parent can be chosen to see everything under it.
+  const QStringList segments = normalized.split(QLatin1Char('/'));
+  for (qsizetype depth = 1; depth <= segments.size(); ++depth) {
+    const QString level = segments.first(depth).join(QLatin1Char('/'));
+    bool present = false;
+    for (const QString& existing : m_tags.keys()) {
+      if (existing.compare(level, Qt::CaseInsensitive) == 0) {
+        present = true;
+        break;
+      }
+    }
+    if (!present) {
+      m_tags.insert(level, {});
+    }
+  }
   persistTags();
   emit tagsChanged();
   return true;
 }
 
 void AppSettings::deleteTag(const QString& name) {
-  if (m_tags.remove(name) == 0) {
+  int removed = m_tags.remove(name);
+  for (const QString& existing : m_tags.keys()) {
+    if (tagIsUnder(existing, name)) {
+      removed += m_tags.remove(existing);
+    }
+  }
+  if (removed == 0) {
     return;
   }
   persistTags();
@@ -824,6 +899,25 @@ void AppSettings::setRating(const QStringList& paths, int rating) {
   emit marksChanged();
 }
 
+QString AppSettings::caption(const QString& path) const { return m_captions.value(path); }
+
+void AppSettings::setCaption(const QString& path, const QString& text) {
+  if (path.isEmpty()) {
+    return;
+  }
+  const QString clean = text.trimmed().left(kMaximumCaptionLength);
+  if (m_captions.value(path) == clean) {
+    return;
+  }
+  if (clean.isEmpty()) {
+    m_captions.remove(path);
+  } else {
+    m_captions.insert(path, clean);
+  }
+  persistMarks();
+  emit marksChanged();
+}
+
 void AppSettings::toggleHidden(const QString& path) {
   if (path.isEmpty()) {
     return;
@@ -868,6 +962,9 @@ QStringList AppSettings::markedPaths() const {
   for (auto it = m_ratings.cbegin(); it != m_ratings.cend(); ++it) {
     all.insert(it.key());
   }
+  for (auto it = m_captions.cbegin(); it != m_captions.cend(); ++it) {
+    all.insert(it.key());
+  }
   return QStringList(all.begin(), all.end());
 }
 
@@ -877,6 +974,7 @@ void AppSettings::forgetMarks(const QStringList& paths) {
     changed = m_favorites.remove(path) || changed;
     changed = m_hidden.remove(path) || changed;
     changed = m_ratings.remove(path) > 0 || changed;
+    changed = m_captions.remove(path) > 0 || changed;
   }
   if (changed) {
     persistMarks();
@@ -893,4 +991,9 @@ void AppSettings::persistMarks() {
   }
   ratings.sort();
   m_settings.setValue(kRatings, ratings);
+  QVariantMap captions;
+  for (auto it = m_captions.cbegin(); it != m_captions.cend(); ++it) {
+    captions.insert(it.key(), it.value());
+  }
+  m_settings.setValue(kCaptions, captions);
 }

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -96,6 +96,8 @@ public:
   Q_INVOKABLE void removeUnavailableFromAlbum(const QString& name);
   void reconcileAlbums(const QList<CaptureRecord>& records);
 
+  // Tags nest with a slash: "Travel/Japan" sits under "Travel". Names come
+  // back in tree order, and a parent's paths include every descendant's.
   [[nodiscard]] QStringList tagNames() const;
   Q_INVOKABLE [[nodiscard]] QStringList tagPaths(const QString& name) const;
   Q_INVOKABLE [[nodiscard]] QStringList tagsForPath(const QString& path) const;
@@ -122,6 +124,10 @@ public:
   Q_INVOKABLE [[nodiscard]] int rating(const QString& path) const;
   Q_INVOKABLE void setRating(const QStringList& paths, int rating);
   [[nodiscard]] int ratedCount() const { return static_cast<int>(m_ratings.size()); }
+  // A short free-text caption. Searched with filenames and picture text.
+  // Empty removes the entry.
+  Q_INVOKABLE [[nodiscard]] QString caption(const QString& path) const;
+  Q_INVOKABLE void setCaption(const QString& path, const QString& text);
 
   // Keep user-owned organization attached when an explicit in-app rename
   // changes the path. Discovery itself remains read-only.
@@ -180,6 +186,7 @@ private:
   QSet<QString> m_favorites;
   QSet<QString> m_hidden;
   QHash<QString, int> m_ratings;
+  QHash<QString, QString> m_captions;
 
   bool m_showHidden = false;
   int m_sortMode = 0;

--- a/src/library/CaptureFilterModel.cpp
+++ b/src/library/CaptureFilterModel.cpp
@@ -1012,8 +1012,9 @@ bool CaptureFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex& sour
   if (!m_searchTerms.isEmpty()) {
     const QString name = record.fileName.toCaseFolded();
     const QString text = m_ocrFolded.value(record.path);
+    const QString caption = record.caption.toCaseFolded();
     for (const QString& term : m_searchTerms) {
-      if (!name.contains(term) && !text.contains(term)) {
+      if (!name.contains(term) && !text.contains(term) && !caption.contains(term)) {
         return false;
       }
     }

--- a/src/library/CaptureModel.cpp
+++ b/src/library/CaptureModel.cpp
@@ -284,6 +284,8 @@ QVariant CaptureModel::data(const QModelIndex& index, int role) const {
     return record.lens;
   case CaptureRoles::RatingRole:
     return record.rating;
+  case CaptureRoles::CaptionRole:
+    return record.caption;
   default:
     return {};
   }
@@ -309,6 +311,7 @@ QHash<int, QByteArray> CaptureModel::roleNames() const {
       {CaptureRoles::CameraRole, "camera"},
       {CaptureRoles::LensRole, "lens"},
       {CaptureRoles::RatingRole, "rating"},
+      {CaptureRoles::CaptionRole, "caption"},
   };
 }
 
@@ -471,6 +474,7 @@ void CaptureModel::adoptResults(ScanResult result) {
       record.favorite = m_settings->isFavorite(record.path);
       record.hidden = m_settings->isHidden(record.path);
       record.rating = m_settings->rating(record.path);
+      record.caption = m_settings->caption(record.path);
     }
   }
 
@@ -612,16 +616,19 @@ void CaptureModel::applyMarks() {
     const bool favorite = m_settings->isFavorite(record.path);
     const bool hidden = m_settings->isHidden(record.path);
     const int rating = m_settings->rating(record.path);
-    if (favorite == record.favorite && hidden == record.hidden && rating == record.rating) {
+    const QString caption = m_settings->caption(record.path);
+    if (favorite == record.favorite && hidden == record.hidden && rating == record.rating &&
+        caption == record.caption) {
       continue;
     }
     record.favorite = favorite;
     record.hidden = hidden;
     record.rating = rating;
+    record.caption = caption;
     const QModelIndex changed = index(static_cast<int>(row), 0);
     emit dataChanged(changed, changed,
                      {CaptureRoles::FavoriteRole, CaptureRoles::HiddenRole,
-                      CaptureRoles::RatingRole});
+                      CaptureRoles::RatingRole, CaptureRoles::CaptionRole});
   }
 }
 

--- a/src/library/CaptureRecord.h
+++ b/src/library/CaptureRecord.h
@@ -53,6 +53,7 @@ struct CaptureRecord {
   bool hidden = false;
   // Stars, 1 to 5; zero is unrated.
   int rating = 0;
+  QString caption;
 
   [[nodiscard]] bool isVideo() const { return video; }
   [[nodiscard]] bool isDocument() const { return document || kind == Document; }

--- a/src/library/CaptureRoles.h
+++ b/src/library/CaptureRoles.h
@@ -25,6 +25,7 @@ enum Role {
   CameraRole,
   LensRole,
   RatingRole,
+  CaptionRole,
   // Added by CaptureFilterModel while a search result needs OCR context.
   OcrSnippetRole,
 };

--- a/tests/tst_omaroll.cpp
+++ b/tests/tst_omaroll.cpp
@@ -627,6 +627,28 @@ private slots:
     QCOMPARE(settings.tagsForPath(original), QStringList {tag});
     QCOMPARE(settings.tagItemCount(tag), 1);
 
+    // A slash nests. The parent's paths and count include the child's, the
+    // names come back in tree order, and creating a deep tag fills in the
+    // levels above it. Deleting a parent takes its children with it.
+    const QString child = tag + QStringLiteral("/ Japan ");
+    const QString other = dir.filePath(QStringLiteral("other.png"));
+    QVERIFY(image.save(other, "PNG"));
+    QVERIFY(settings.createTag(child));
+    const QString childName = tag + QStringLiteral("/Japan");
+    QVERIFY(settings.tagNames().contains(childName));
+    QVERIFY(!settings.createTag(QStringLiteral(" / / ")));
+    QVERIFY(settings.addTag(childName, {other}));
+    QCOMPARE(settings.tagPaths(childName), QStringList {other});
+    QCOMPARE(settings.tagPaths(tag), QStringList({original, other}));
+    QCOMPARE(settings.tagItemCount(tag), 2);
+    QVERIFY(settings.tagNames().indexOf(tag) < settings.tagNames().indexOf(childName));
+    const QString deep = QStringLiteral("Auto ") + suffix + QStringLiteral("/Level/Leaf");
+    QVERIFY(settings.createTag(deep));
+    QVERIFY(settings.tagNames().contains(QStringLiteral("Auto ") + suffix));
+    QVERIFY(settings.tagNames().contains(QStringLiteral("Auto ") + suffix + QStringLiteral("/Level")));
+    settings.deleteTag(QStringLiteral("Auto ") + suffix);
+    QVERIFY(!settings.tagNames().contains(deep));
+
     QVariantMap view;
     view.insert(QStringLiteral("kind"), CaptureRecord::Picture);
     view.insert(QStringLiteral("favorites"), true);
@@ -634,17 +656,18 @@ private slots:
     QVERIFY(settings.saveSmartCollection(collection, view));
 
     AppSettings restored;
-    QCOMPARE(restored.tagPaths(tag), QStringList {original});
+    QCOMPARE(restored.tagPaths(tag), QStringList({original, other}));
     QCOMPARE(restored.smartCollection(collection), view);
     QVERIFY(QFile::rename(original, renamed));
     restored.relocatePath(original, renamed);
-    QCOMPARE(restored.tagPaths(tag), QStringList {renamed});
+    QCOMPARE(restored.tagPaths(tag), QStringList({renamed, other}));
     QCOMPARE(restored.tagsForPath(renamed), QStringList {tag});
 
     AppSettings finalRestore;
-    QCOMPARE(finalRestore.tagPaths(tag), QStringList {renamed});
+    QCOMPARE(finalRestore.tagPaths(tag), QStringList({renamed, other}));
     QCOMPARE(finalRestore.smartCollection(collection), view);
     finalRestore.deleteTag(tag);
+    QVERIFY(!finalRestore.tagNames().contains(childName));
     finalRestore.deleteSmartCollection(collection);
   }
 
@@ -1136,6 +1159,17 @@ private slots:
     proxy.setSearchText(QStringLiteral("beach overdue"));
     QCOMPARE(proxy.count(), 1);
     QCOMPARE(proxy.pathAt(0), beachPath);
+    proxy.setSearchText({});
+
+    // A caption is searched like the filename and the picture text.
+    settings.setCaption(beachPath, QStringLiteral("Sunset from the pier"));
+    QTRY_COMPARE_WITH_TIMEOUT(model.recordAt(model.rowOf(beachPath)).caption,
+                              QStringLiteral("Sunset from the pier"), 1000);
+    proxy.setSearchText(QStringLiteral("pier"));
+    QCOMPARE(proxy.count(), 1);
+    QCOMPARE(proxy.pathAt(0), beachPath);
+    settings.setCaption(beachPath, QString());
+    QTRY_COMPARE_WITH_TIMEOUT(proxy.count(), 0, 1000);
     proxy.setSearchText({});
 
     rescanned.clear();
@@ -2744,6 +2778,9 @@ private slots:
     QCOMPARE(settings.rating(original), 4);
     QCOMPARE(settings.ratedCount(), 1);
 
+    settings.setCaption(original, QStringLiteral("  Boarding pass  "));
+    QCOMPARE(settings.caption(original), QStringLiteral("Boarding pass"));
+
     ActionLauncher launcher;
     QVERIFY(!launcher.renameFile(original, QString()).value(QStringLiteral("ok")).toBool());
     QVERIFY(!launcher.renameFile(original, QStringLiteral("bad/name"))
@@ -2768,6 +2805,9 @@ private slots:
     QVERIFY(settings.isHidden(newPath));
     QCOMPARE(settings.rating(newPath), 4);
     QCOMPARE(settings.rating(original), 0);
+
+    QCOMPARE(settings.caption(newPath), QStringLiteral("Boarding pass"));
+    QVERIFY(settings.caption(original).isEmpty());
     QCOMPARE(settings.albumPaths(album), QStringList {newPath});
     AppSettings restored;
     QVERIFY(restored.isFavorite(newPath));
@@ -2783,6 +2823,12 @@ private slots:
     QCOMPARE(settings.ratedCount(), 0);
     QVERIFY(!settings.markedPaths().contains(newPath) || settings.isFavorite(newPath));
 
+
+    QCOMPARE(restored.caption(newPath), QStringLiteral("Boarding pass"));
+    QCOMPARE(restored.albumPaths(album), QStringList {newPath});
+
+    settings.setCaption(newPath, QString());
+    QVERIFY(settings.caption(newPath).isEmpty());
     settings.toggleFavorite(newPath);
     settings.toggleHidden(newPath);
     settings.deleteAlbum(album);

--- a/tests/tst_ui.cpp
+++ b/tests/tst_ui.cpp
@@ -61,7 +61,6 @@
 #include <QVideoFrame>
 #include <QtTest>
 
-#include <functional>
 #include <algorithm>
 
 class UiTest : public QObject {
@@ -758,6 +757,33 @@ private slots:
     QTRY_COMPARE(m_settings->rating(first), 0);
     QTest::keyClick(m_window, Qt::Key_Escape);
     QTRY_VERIFY(!detail->isVisible());
+  }
+
+  void viewerCaptionSavesOnEnterAndShowsOnTheTile() {
+    QQuickItem* detail = item("detail");
+    const QString first = pathAt(0);
+    openDetail(0);
+    QTRY_VERIFY(detail->isVisible());
+    QQuickItem* field = detail->findChild<QQuickItem*>(QStringLiteral("viewerCaption"));
+    QVERIFY(field);
+    field->forceActiveFocus();
+    QTRY_VERIFY(field->hasActiveFocus());
+    typeText(QStringLiteral("Trip notes"));
+    QTest::keyClick(m_window, Qt::Key_Return);
+    QTRY_COMPARE(m_settings->caption(first), QStringLiteral("Trip notes"));
+    QTRY_COMPARE(detail->property("caption").toString(), QStringLiteral("Trip notes"));
+    QVERIFY(!field->hasActiveFocus());
+    // Enter handed focus back to the picture, so the viewer's own keys work.
+    QTest::keyClick(m_window, Qt::Key_Escape);
+    QTRY_VERIFY(!detail->isVisible());
+    QTRY_COMPARE(m_library->data(m_library->index(0, 0), CaptureRoles::CaptionRole).toString(),
+                 QStringLiteral("Trip notes"));
+    // The grid may still be rebuilding delegates from an earlier filter
+    // change, so give the tile a moment to pick the caption up.
+    QTRY_VERIFY(cardFor(first) != nullptr);
+    QTRY_COMPARE(cardFor(first)->property("caption").toString(), QStringLiteral("Trip notes"));
+    m_settings->setCaption(first, QString());
+    QTRY_VERIFY(m_settings->caption(first).isEmpty());
   }
 
   void exactDuplicatesOpenAsAGroupedReviewView() {
@@ -2176,8 +2202,11 @@ private:
 
   QQuickItem* cardFor(const QString& path) const {
     return find(m_window->contentItem(), [&path](QQuickItem* candidate) {
+      // A relayout releases the previous delegates a moment after the new
+      // ones appear; those keep a -1 index and must not answer for the tile.
       return candidate->property("dragPaths").isValid() &&
-             candidate->property("path").toString() == path && candidate->isVisible();
+             candidate->property("path").toString() == path && candidate->isVisible() &&
+             candidate->parentItem() && candidate->parentItem()->property("index").toInt() >= 0;
     });
   }
 


### PR DESCRIPTION
Tags nest with a slash. Creating "Travel/Japan" also creates "Travel" so the tree has no gaps, the Browse tag list draws children indented under their parent (full names when a search would hide the parent), and choosing a parent shows everything beneath it because tagPaths and tagItemCount include descendants. Deleting a parent removes its children too and the Delete tooltip says so. Storage is unchanged apart from allowing the slash in stored names, which the loader previously dropped.

Captions are a short free-text field per file, stored with favourites and hidden marks in the ini, following in-app renames and forgotten when a file is gone. The viewer gets a caption field under the file details; Enter or leaving the field saves, Escape reverts. The tile shows the caption in the bottom strip when there is no search snippet to show, and search matches captions alongside filenames and picture text.

Tests cover nesting, tree order, parent counts, auto-created levels and parent deletion, caption persistence and relocation, caption search, and the viewer caption field through to the tile. Core and UI suites pass in the sandbox.

Linear: SBS-1142
