### PR TITLE
Handle Tab and Shift+Tab in the grid so Shift+Tab is not an ambiguous shortcut

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -775,6 +775,10 @@ ApplicationWindow {
         anchors.bottomMargin: 4
         focus: !root.anySheetOpen
         enabled: !root.anySheetOpen && !root.popupOpen
+        // Tab walks the sections the way it walks tabs in a browser, while
+        // the grid has the keyboard. The search field, sheets and menus keep
+        // their own Tab because the grid never sees it then.
+        onSectionStepRequested: function (step) { filters.cycleSection(step) }
 
         model: Captures
         visible: Captures.count > 0
@@ -1459,19 +1463,6 @@ ApplicationWindow {
                 onActivated: filters.selectSection(sectionKey.index)
             }
         }
-    }
-    // Tab walks the sections the way it walks tabs in a browser. The window
-    // owns it, so it does not traverse the pills; those keep the number keys
-    // and the mouse. The search field, sheets and menus own their own Tab.
-    Shortcut {
-        sequences: ["Tab"]
-        enabled: !root.anySheetOpen && !root.popupOpen && !filters.searchActive
-        onActivated: filters.cycleSection(1)
-    }
-    Shortcut {
-        sequences: ["Shift+Tab", "Backtab", "Shift+Backtab"]
-        enabled: !root.anySheetOpen && !root.popupOpen && !filters.searchActive
-        onActivated: filters.cycleSection(-1)
     }
     // Alt with a digit rates. Plain digits already jump between sections,
     // and the viewer keeps 0 and 1 for zoom, so the modifier is the same in

--- a/qml/components/CaptureGrid.qml
+++ b/qml/components/CaptureGrid.qml
@@ -28,6 +28,11 @@ FocusScope {
     signal chosen(int index)
     signal deleteRequested(string path)
     signal detailRequested(int index)
+    // Tab and Shift+Tab walk the sections. Handled here as key events rather
+    // than window shortcuts: on a real keyboard Shift+Tab arrives as Backtab,
+    // and Qt's shortcut matcher also offers plain Tab for that key, so two
+    // shortcuts match, the press counts as ambiguous, and neither fires.
+    signal sectionStepRequested(int step)
 
     // Include every intersecting cell, including the partial bottom row.
     // Cached offscreen delegates do not count, nor does an empty library.
@@ -369,6 +374,14 @@ FocusScope {
                 break
             case Qt.Key_L:
                 grid.moveCurrentIndexRight()
+                event.accepted = true
+                break
+            case Qt.Key_Tab:
+                root.sectionStepRequested(event.modifiers & Qt.ShiftModifier ? -1 : 1)
+                event.accepted = true
+                break
+            case Qt.Key_Backtab:
+                root.sectionStepRequested(-1)
                 event.accepted = true
                 break
             case Qt.Key_Home:


### PR DESCRIPTION
On a real keyboard Shift+Tab arrives as Backtab and Qt's shortcut matcher also offers plain Tab as a possible key for it. Both window shortcuts matched, Qt treated the press as ambiguous and neither fired, so Shift+Tab did nothing on the desktop while Tab worked. The offscreen test harness bypasses the keyboard map, which is why the UI test passed.

The grid now handles Tab and Backtab as key events and asks the filter bar to step, and the two window shortcuts are gone. The search field, sheets and menus keep their own Tab since the grid never sees the key while they have focus. Existing UI test covers both directions and the wrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the capture grid.
  * Tab now advances through filter sections, while Shift+Tab moves to the previous section.
  * Section cycling is handled consistently when focus is within the capture grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->