### PR TITLE
Hold the first frame after a video ends and save captions on Enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 - Captions. Add a short caption in the viewer; it shows on the tile and is
   searched with filenames and picture text.
 
+### Changed
+
+- A video that plays to its end rewinds to its first frame and pauses there
+  instead of leaving a blank stage.
+
 ## 1.5.0
 
 ### Added

--- a/qml/components/DetailSheet.qml
+++ b/qml/components/DetailSheet.qml
@@ -1370,17 +1370,28 @@ Item {
                         readonly property string saved: root.caption
                         onSavedChanged: text = saved
                         Component.onCompleted: text = saved
-                        onEditingFinished: {
+                        function commit() {
                             if (text.trim() !== root.caption) {
                                 root.captionEdited(text.trim())
                             }
                         }
-                        Keys.onEscapePressed: {
-                            text = root.caption
+                        // Enter saves outright. Handing focus back to the
+                        // sheet is not enough on its own: a focus scope
+                        // returns focus to its current item, which is this
+                        // field, so the focus-out save would never fire.
+                        function finish() {
+                            commit()
+                            focus = false
                             root.focusPreview()
                         }
-                        Keys.onReturnPressed: root.focusPreview()
-                        Keys.onEnterPressed: root.focusPreview()
+                        onEditingFinished: commit()
+                        Keys.onEscapePressed: {
+                            text = root.caption
+                            focus = false
+                            root.focusPreview()
+                        }
+                        Keys.onReturnPressed: finish()
+                        Keys.onEnterPressed: finish()
                     }
 
                     Text {

--- a/qml/components/DetailSheet.qml
+++ b/qml/components/DetailSheet.qml
@@ -741,9 +741,19 @@ Item {
                             }
                         }
                         onMediaStatusChanged: {
-                            if (mediaStatus === MediaPlayer.EndOfMedia && root.slideshowRunning) {
-                                root.requestNavigation(1)
+                            if (mediaStatus !== MediaPlayer.EndOfMedia) {
+                                return
                             }
+                            if (root.slideshowRunning) {
+                                root.requestNavigation(1)
+                                return
+                            }
+                            // A finished clip stops and the backend drops its
+                            // frame, leaving a blank stage that reads as broken.
+                            // Rewind to the first frame and hold it, so the
+                            // picture stays and the play button means replay.
+                            pause()
+                            position = 0
                         }
                     }
                 }

--- a/tests/tst_ui.cpp
+++ b/tests/tst_ui.cpp
@@ -1820,6 +1820,16 @@ private slots:
     QTRY_COMPARE(player->playbackState(), QMediaPlayer::PausedState);
     m_window->showNormal();
     QTRY_COMPARE(player->playbackState(), QMediaPlayer::PlayingState);
+    // A clip that reaches its end holds its first frame, paused, instead of
+    // stopping on a blank stage; Space then plays it again from the start.
+    player->setPosition(player->duration() - 300);
+    QTRY_COMPARE_WITH_TIMEOUT(player->playbackState(), QMediaPlayer::PausedState, 5000);
+    QTRY_VERIFY(player->position() < 500);
+    QVERIFY(player->hasVideo());
+    QVERIFY(item("videoOutput")->isVisible());
+    QTest::keyClick(m_window, Qt::Key_Space);
+    QTRY_COMPARE(player->playbackState(), QMediaPlayer::PlayingState);
+    QTRY_VERIFY(player->position() > 0 && player->position() < 3000);
     // Basic controls must remain within the narrow window.
     m_window->resize(560, 420);
     QTest::qWait(100);

--- a/tests/tst_ui.cpp
+++ b/tests/tst_ui.cpp
@@ -773,6 +773,24 @@ private slots:
     QTRY_COMPARE(m_settings->caption(first), QStringLiteral("Trip notes"));
     QTRY_COMPARE(detail->property("caption").toString(), QStringLiteral("Trip notes"));
     QVERIFY(!field->hasActiveFocus());
+
+    // Arrow to the next file and caption that one too. Enter must save on
+    // its own, whatever focus the sheet held before the field was clicked.
+    QTest::keyClick(m_window, Qt::Key_Right);
+    const QString second = detail->property("path").toString();
+    QTRY_VERIFY(second != first);
+    QTRY_VERIFY(detail->property("caption").toString().isEmpty());
+    QVERIFY(field->property("text").toString().isEmpty());
+    field->forceActiveFocus();
+    QTRY_VERIFY(field->hasActiveFocus());
+    typeText(QStringLiteral("Second one"));
+    QTest::keyClick(m_window, Qt::Key_Return);
+    QTRY_COMPARE(m_settings->caption(second), QStringLiteral("Second one"));
+    QVERIFY(!field->hasActiveFocus());
+    QTest::keyClick(m_window, Qt::Key_Left);
+    QTRY_COMPARE(detail->property("path").toString(), first);
+    QTRY_COMPARE(field->property("text").toString(), QStringLiteral("Trip notes"));
+    m_settings->setCaption(second, QString());
     // Enter handed focus back to the picture, so the viewer's own keys work.
     QTest::keyClick(m_window, Qt::Key_Escape);
     QTRY_VERIFY(!detail->isVisible());


### PR DESCRIPTION
Two viewer fixes from the desktop pass.

A video that plays to its end used to stop on a blank stage because the backend drops its frame once playback stops. The viewer now pauses on the first frame at the end, so the picture stays and the play button reads as replay. Slideshows still advance.

Pressing Enter in the caption field handed focus to the sheet's focus scope, which gives focus straight back to its current item, the field itself. The save only ran on focus loss, so whether Enter saved depended on where focus was before the field was clicked. Enter now commits the caption directly and drops the field's focus. The UI test captions two files in a row, arrowing between them.