### PR TITLE
Pluralize the header count against the total when a filter narrows it

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -622,7 +622,9 @@ ApplicationWindow {
                     }
                     const shown = Captures.count
                     const total = Captures.sourceCount
-                    const noun = shown === 1 ? " item" : " items"
+                    // "1 of 420 items": the noun follows the number it sits
+                    // next to, which is the total once a filter narrows it.
+                    const noun = (shown === total ? shown : total) === 1 ? " item" : " items"
                     return shown === total
                            ? root.formatCount(shown) + noun
                            : root.formatCount(shown) + " of " + root.formatCount(total) + noun


### PR DESCRIPTION
With a filter active the header read "1 of 420 item". The noun now follows the total, so it reads "1 of 420 items" and still "1 item" for an unfiltered single file.