### PR TITLE
Prepare Omaroll 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.6.0
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### Added
 
-- Tab and Shift+Tab step through the sections, wrapping at either end.
-- Browse a photo library by camera and lens. The metadata pass that reads
-  capture dates now records the camera and lens too, and saved views keep
-  the choice. Libraries without camera photos do not show the section.
 - Star ratings. Rate a file from the viewer or with Alt+1 to Alt+5, sort by
   Top rated, and narrow any view to a minimum rating from Browse. Saved views
   keep the choice.
-- Nested tags. A tag named Travel/Japan sits under Travel in Browse, and
-  choosing the parent shows everything beneath it.
 - Captions. Add a short caption in the viewer; it shows on the tile and is
   searched with filenames and picture text.
+- Nested tags. A tag named Travel/Japan sits under Travel in Browse, and
+  choosing the parent shows everything beneath it.
+- Browse a photo library by camera and lens. The metadata pass that reads
+  capture dates now records the camera and lens too, and saved views keep
+  the choice. Libraries without camera photos do not show the section.
+- Tab and Shift+Tab step through the sections, wrapping at either end.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(Omaroll VERSION 1.5.0 LANGUAGES CXX)
+project(Omaroll VERSION 1.6.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -217,10 +217,10 @@ Documents: PDF. Thumbnails, previews, and page counts use Poppler locally.
 Requires Omarchy or Arch with Qt 6.8+ and Poppler.
 
 ```bash
-curl -fLO https://github.com/btsouth/omaroll/releases/download/v1.5.0/omaroll-1.5.0-1-x86_64.pkg.tar.zst \
-     -fLO https://github.com/btsouth/omaroll/releases/download/v1.5.0/SHA256SUMS
+curl -fLO https://github.com/btsouth/omaroll/releases/download/v1.6.0/omaroll-1.6.0-1-x86_64.pkg.tar.zst \
+     -fLO https://github.com/btsouth/omaroll/releases/download/v1.6.0/SHA256SUMS
 sha256sum -c --ignore-missing SHA256SUMS
-sudo pacman -U ./omaroll-1.5.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./omaroll-1.6.0-1-x86_64.pkg.tar.zst
 ```
 
 Run the same commands for a newer release to update. The package is prepared for

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing Omaroll
 
 Start with [current status](docs/STATUS.md). v1.5.0 is the latest published
-release. A version is released only when its tag is pushed after desktop
-acceptance.
+release. Version 1.6.0 is prepared in the tree and is released only when its
+tag is pushed after desktop acceptance.
 
 1. Update the version in `CMakeLists.txt`, AppStream metadata, the changelog,
    README package command, and public feature descriptions.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Project status and handoff
 
-Snapshot: 5 September 2026 UTC, after the v1.5.0 release and four feature merges
-to main. Check the linked PRs and release before resuming.
+Snapshot: 5 September 2026 UTC, with 1.6.0 prepared after the v1.5.0 release and
+the feature merges that followed. Check the linked PRs and release before resuming.
 
 ## Released
 
@@ -47,11 +47,16 @@ of 949.9 to 257.2 ms for an image-ready submitted frame and 1181.2 to 471.9 ms
 for a ready grid. These are offscreen NVIDIA measurements from main entry,
 not compositor presentation or general performance guarantees.
 
-## Unreleased on main
+## 1.6.0 candidate
 
 Four feature PRs landed after the release, each squash merged with green CI and
-passing core and UI suites in the sandbox. None has had a physical desktop test
-yet, so they are not part of any tag until that gate is passed:
+passing core and UI suites in the sandbox. All were tested on the real Omarchy
+desktop on 5 September 2026, which found three problems fixed in
+[PR #16](https://github.com/btsouth/omaroll/pull/16) (Shift+Tab was an
+ambiguous shortcut), [PR #17](https://github.com/btsouth/omaroll/pull/17)
+(caption save depended on focus; a finished video left a blank stage) and
+[PR #18](https://github.com/btsouth/omaroll/pull/18) (header count wording).
+Version 1.6.0 carries all of it:
 
 - [PR #11](https://github.com/btsouth/omaroll/pull/11): Tab and Shift+Tab cycle
   the section pills.
@@ -63,7 +68,7 @@ yet, so they are not part of any tag until that gate is passed:
 - [PR #14](https://github.com/btsouth/omaroll/pull/14): tags nest with a slash
   and files take a caption in the viewer that is searched with names and text.
 
-The changelog carries them under Unreleased. Semantic search and face
+The changelog lists them under 1.6.0. Semantic search and face
 recognition were considered against Lightroom and Immich and deferred
 (SBS-1139); do not add ML dependencies without a fresh decision.
 

--- a/packaging/io.github.tsouth89.omaroll.metainfo.xml
+++ b/packaging/io.github.tsouth89.omaroll.metainfo.xml
@@ -37,6 +37,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.0" date="2026-09-05"/>
     <release version="1.5.0" date="2026-09-05"/>
     <release version="1.4.0" date="2026-09-04"/>
     <release version="1.3.1" date="2026-09-03"/>


### PR DESCRIPTION
Bumps the project to 1.6.0, adds the AppStream release entry, closes the changelog section, points the README package command at the 1.6.0 assets and records the candidate in RELEASING.md and STATUS.md.

The candidate is main after PRs #11 to #18: Tab cycling, camera and lens browsing, star ratings, nested tags, captions, the video end frame, the caption save fix and the header count wording. All of it was desktop tested on the Omarchy session on 5 September.

Local validation at this version: core suite, UI suite, OpenGL suite, grid, video and OCR renders, desktop-file and AppStream validation.
